### PR TITLE
WF4: tag collision guard — refuse any existing tag, regardless of minter

### DIFF
--- a/docs/developer/05-Tag Guard.md
+++ b/docs/developer/05-Tag Guard.md
@@ -66,8 +66,32 @@ would have waved those two through.
 The guard therefore reads **ref names only**. The `TagReader` interface exposes
 `All()`, `Visible()` and `IsShallow()` and offers no way to read a tag's tagger,
 committer, date or message. Identity is not "not consulted by convention" — it is
-**unrepresentable in the interface**, and the shipped bundle is asserted to
-contain no `taggername` / `taggeremail` / `taggerdate` / `committername` token.
+**unrepresentable in the interface**.
+
+That is enforced two ways, because one of them is behavioural and one is
+structural and they fail independently:
+
+- **Behaviourally** (`sabotage/wf4-tag-collision-guard.sh` ARM 3 + ARM 4): the
+  same version is refused when its tag is minted by `kirinnee` and when it is
+  minted by `atomi-bot`. The _pair_ is the proof — either arm alone is consistent
+  with a guard that happens to care about identity.
+- **Structurally** (ARM 14): the shipped `dist/` tree is asserted to contain none
+  of the git ref-format tokens that could extract identity — `taggername`,
+  `taggeremail`, `taggerdate`, `tagger`, `committername`, `committeremail`,
+  `committerdate`, `creator`, `creatordate`, `authorname`, `authoremail`. The
+  vocabulary is listed because an absence claim is only as wide as its word list.
+  The subject is that token set and **not** English words: the guard's own
+  refusal message legitimately contains "author" and "minted", so an English-word
+  sweep would report a false hit and invite someone to delete the explanation to
+  make the check pass.
+
+**Note for anyone extending ARM 14:** `tsc` does **not** bundle. It emits ~40
+separate files and `dist/semantic-generator.js` is a ~2.9 KB entry point that
+merely requires the others; the guard's bytes live in
+`dist/classLibrary/release/tag-guard.js`. Scanning the entry file alone examines
+nothing and passes unconditionally. The first draft of ARM 14 did exactly that
+and was caught only by its own must-differ control, which asserts the same grep
+over the same population still finds a token that _is_ present.
 
 `All()` uses `git for-each-ref refs/tags`, not `git tag --list`, because
 `for-each-ref` applies no implicit reachability filter and returns names only.

--- a/docs/developer/05-Tag Guard.md
+++ b/docs/developer/05-Tag Guard.md
@@ -1,0 +1,107 @@
+---
+id: tag-guard
+title: Tag Collision Guard
+---
+
+# `sg tag-guard`
+
+Refuses to compute a release onto a version an existing tag already occupies —
+**regardless of who minted the tag.**
+
+```bash
+sg tag-guard              # visibility arm only (no version known yet)
+sg tag-guard 1.4.0        # visibility arm + "is 1.4.0 already taken?"
+sg tag-guard 1.4.0 --cwd /path/to/repo
+```
+
+Exit `0` means the release may proceed. Exit `1` means it may not, and every
+reason is printed to **stderr** with a stable machine-readable code.
+
+The same guard runs as a **mandatory preflight inside `sg release`**, before any
+version is computed and before the configuration is even read. It has no bypass
+flag.
+
+## The hazard this closes
+
+Measured on a live repository:
+
+- `git tag --merged <branch>` returned **0** tags, so the releaser computed
+  `1.0.0` from scratch.
+- The repository already carried `v1.0.0` — plus ten further v-tags
+  (`v0.1.0 v0.1.1 v1.0.1 v1.0.2 v1.1.0 v1.1.1 v1.1.2 v1.2.0 v1.3.0 v1.3.1`) — on
+  refs the release branch could not reach.
+
+Three properties made that fatal rather than merely wrong:
+
+1. tag validation checked the tag **name** and not its **existence**;
+2. tag creation carried no `-f`, so a collision is an error, not an overwrite;
+3. tagging happens **after** the release commit.
+
+So the failure mode is not "the release stops". It is: the release commit lands,
+the changelog is written, assets are committed — and _only then_ does tag creation
+fail, leaving **a committed release with no tag** on the branch about to be
+pushed.
+
+That instance was cleared by deleting four tags. **The instance closed and the
+class stayed open.** This is the class fix.
+
+## Two arms, because the version is not always known yet
+
+| arm               | question                                                    | when it can run                                              |
+| ----------------- | ----------------------------------------------------------- | ------------------------------------------------------------ |
+| `CheckVersion`    | is _this_ version's tag already taken?                      | when a concrete version is in hand (a bump, an explicit ask) |
+| `CheckVisibility` | does this repository hold version tags `HEAD` cannot reach? | always — including before the next version has been computed |
+
+The visibility arm is the one that catches the incident above. It is the only
+check that can be made **before** semantic-release computes a version, and an
+unreachable version tag is exactly the condition under which the computed version
+can land on one.
+
+## "Regardless of who minted it" is a requirement, not a nicety
+
+Of the four tags that blocked a release on this fleet, **two were the human
+owner's.** A guard that treated machine-minted and human-minted tags differently
+would have waved those two through.
+
+The guard therefore reads **ref names only**. The `TagReader` interface exposes
+`All()`, `Visible()` and `IsShallow()` and offers no way to read a tag's tagger,
+committer, date or message. Identity is not "not consulted by convention" — it is
+**unrepresentable in the interface**, and the shipped bundle is asserted to
+contain no `taggername` / `taggeremail` / `taggerdate` / `committername` token.
+
+`All()` uses `git for-each-ref refs/tags`, not `git tag --list`, because
+`for-each-ref` applies no implicit reachability filter and returns names only.
+Annotated and lightweight tags are indistinguishable to it, which is the point.
+
+## Refusal codes
+
+| code              | meaning                                                                       |
+| ----------------- | ----------------------------------------------------------------------------- |
+| `tag-collision`   | a tag for the asked version already exists (with or without the `v` prefix)   |
+| `tag-not-visible` | version tags exist in the repository that `HEAD` cannot reach                 |
+| `invalid-version` | the asked version is not full `x.y.z`; refused rather than guessed at         |
+| `shallow-clone`   | the clone is shallow, so the tag set is incomplete and nothing can be cleared |
+| `not-a-git-repo`  | the tags could not be read at all                                             |
+
+### Refusing is the correct answer to "I could not check"
+
+`shallow-clone` and `not-a-git-repo` are **refusals, not skips**. "I could not
+look" and "I looked and it is clear" are different verdicts and only one of them
+is safe to release on. A guard that returns `0` when it could not read the tag set
+reports _safe_ while having measured nothing — which is the shape of an inert
+check, and inert checks are worse than missing ones because they retire the doubt.
+
+## What is deliberately _not_ treated as a version tag
+
+`semantic-release-major-tag` mints floating `v3` and `v3.1` tags and **moves
+them** on every release. They are not full versions, and they are unreachable from
+`HEAD` roughly whenever they have just been moved. Counting them as version tags
+would make every release refuse itself. Only `x.y.z` (optionally `v`-prefixed,
+optionally with a prerelease or build suffix) is a version tag here.
+
+## Interaction with the version-bump feature (D5)
+
+When the releaser stamps a computed version into ecosystem manifests, call
+`CheckVersion` with that version first. The bump writes files; the tag proves the
+version was free. Doing it in the other order reproduces hazard property 3 with
+extra steps.

--- a/sabotage/wf4-tag-collision-guard.out
+++ b/sabotage/wf4-tag-collision-guard.out
@@ -6,7 +6,7 @@ CLI under test : /home/kirin/Workspace/wt-sg-wf4-tagguard/dist/semantic-generato
 CLI bytes sha  : 6553921cf677e3d7885d61b5c609a09bc8b3739b04ef07ead56d23a50c7f8643
 git version    : git version 2.54.0
 shell          : bash 5.2.26(1)-release
-scratch root   : /tmp/tmp.Y85dxMBdrO
+scratch root   : /tmp/tmp.4dPSyxXd0I
 
 -- ARM 1/2: a version an existing tag occupies is refused; a free one is not
   PASS  SUBJECT tag v1.0.0 exists in the repo == 'v1.0.0'
@@ -60,7 +60,13 @@ scratch root   : /tmp/tmp.Y85dxMBdrO
   PASS  ARM14 shipped tree (40 .js files under /home/kirin/Workspace/wt-sg-wf4-tagguard/dist) contains none of the 11 tag-identity tokens (taggername taggeremail taggerdate tagger committername committeremail committerdate creator creatordate authorname authoremail)
   PASS  ARM14 CONTROL the same grep over the same tree DOES find 'for-each-ref' (instrument is live)
 
+-- ARM 15: the guard is WIRED INTO 'sg release', not merely available
+  PASS  SUBJECT tags reachable from HEAD == ''
+  PASS  ARM15 'sg release' refused at preflight (exit 1) with 'tag-not-visible'
+  PASS  SUBJECT tag reachable after merge == 'v1.0.0'
+  PASS  ARM15 CONTROL preflight PASSED and release proceeded to a different failure (missing config), proving the refusal above was the guard and not a broken command
+
 == RESULT ==
-arms passed : 28
+arms passed : 32
 arms failed : 0
 VERDICT: ALL PASS

--- a/sabotage/wf4-tag-collision-guard.out
+++ b/sabotage/wf4-tag-collision-guard.out
@@ -1,0 +1,66 @@
+[0mdirenv: loading ~/Workspace/wt-sg-wf4-tagguard/.envrc
+[0mdirenv: using flake
+[0mdirenv: nix-direnv: Using cached dev shell
+== WF4 tag-collision guard — end-to-end proof ==
+CLI under test : /home/kirin/Workspace/wt-sg-wf4-tagguard/dist/semantic-generator.js
+CLI bytes sha  : 6553921cf677e3d7885d61b5c609a09bc8b3739b04ef07ead56d23a50c7f8643
+git version    : git version 2.54.0
+shell          : bash 5.2.26(1)-release
+scratch root   : /tmp/tmp.Y85dxMBdrO
+
+-- ARM 1/2: a version an existing tag occupies is refused; a free one is not
+  PASS  SUBJECT tag v1.0.0 exists in the repo == 'v1.0.0'
+  PASS  ARM1 occupied version 1.0.0 — refused (exit 1) with code 'tag-collision'
+  PASS  ARM2 CONTROL free version 2.0.0 — cleared (exit 0) saying 'is free'
+
+-- ARM 3: an OWNER-MINTED annotated tag is refused (the fleet's live case)
+  PASS  SUBJECT tagger of v1.0.1 == 'kirinnee'
+  PASS  SUBJECT v1.0.1 is an ANNOTATED tag object == 'tag'
+  PASS  ARM3 owner-minted (kirinnee) tag v1.0.1 — refused (exit 1) with code 'tag-collision'
+
+-- ARM 4: a MACHINE-minted annotated tag is refused IDENTICALLY
+  PASS  SUBJECT tagger of v1.0.1 == 'atomi-bot'
+  PASS  ARM4 machine-minted (atomi-bot) tag v1.0.1 — refused (exit 1) with code 'tag-collision'
+
+-- ARM 5: a LIGHTWEIGHT tag (no tagger at all) is refused too
+  PASS  SUBJECT v1.0.2 is NOT an annotated tag object == 'commit'
+  PASS  SUBJECT v1.0.2 has an empty taggername == ''
+  PASS  ARM5 lightweight tag v1.0.2 — refused (exit 1) with code 'tag-collision'
+
+-- ARM 6/7: the MEASURED INCIDENT — a tag HEAD cannot reach
+  PASS  SUBJECT tags reachable from HEAD (the set the releaser computed from) == ''
+  PASS  SUBJECT v1.0.0 nonetheless exists in the repository == 'v1.0.0'
+  PASS  ARM6 visibility arm, 1 tag unreachable — refused (exit 1) with code 'tag-not-visible'
+  PASS  ARM7 unreachable tag still blocks version 1.0.0 — refused (exit 1) with code 'tag-collision'
+
+-- ARM 8: CONTROL — every version tag reachable, so the guard clears
+  PASS  SUBJECT both tags reachable from HEAD == 'v1.0.0,v1.1.0'
+  PASS  ARM8 CONTROL all tags reachable — cleared (exit 0) saying 'reachable from HEAD'
+
+-- ARM 9: CONTROL — floating major/minor tags must NOT trip the guard
+  PASS  SUBJECT v3 and v3.1 are unreachable from HEAD == 'v1.0.0'
+  PASS  ARM9 CONTROL floating v3/v3.1 ignored — cleared (exit 0) saying 'reachable from HEAD'
+
+-- ARM 10: a shallow clone REFUSES rather than reporting a clear result
+  PASS  SUBJECT clone reports itself shallow == 'true'
+  PASS  ARM10 shallow clone — refused (exit 1) with code 'shallow-clone'
+
+-- ARM 11: 'I could not look' is not 'it is clear'
+  PASS  SUBJECT directory is not a git repository == 'NOT_A_REPO'
+  PASS  ARM11 not a git repository — refused (exit 1) with code 'not-a-git-repo'
+
+-- ARM 12: the v-prefix is not a way past the guard
+  PASS  ARM12 bare '2.5.0' against tag 'v2.5.0' — refused (exit 1) with code 'tag-collision'
+  PASS  ARM12b 'v2.6.0' against bare tag '2.6.0' — refused (exit 1) with code 'tag-collision'
+
+-- ARM 13: a malformed version is refused, not guessed at
+  PASS  ARM13 '1.2' is not a full version — refused (exit 1) with code 'invalid-version'
+
+-- ARM 14: the SHIPPED BUNDLE cannot read a tag's identity at all
+  PASS  ARM14 shipped tree (40 .js files under /home/kirin/Workspace/wt-sg-wf4-tagguard/dist) contains none of the 11 tag-identity tokens (taggername taggeremail taggerdate tagger committername committeremail committerdate creator creatordate authorname authoremail)
+  PASS  ARM14 CONTROL the same grep over the same tree DOES find 'for-each-ref' (instrument is live)
+
+== RESULT ==
+arms passed : 28
+arms failed : 0
+VERDICT: ALL PASS

--- a/sabotage/wf4-tag-collision-guard.sh
+++ b/sabotage/wf4-tag-collision-guard.sh
@@ -1,0 +1,395 @@
+#!/usr/bin/env bash
+# WF4 tag-collision guard — end-to-end sabotage proof against REAL git repositories.
+#
+# WHY THIS EXISTS SEPARATELY FROM THE UNIT SUITE
+# ---------------------------------------------
+# tests/release/tag-guard.spec.ts drives the guard through a FakeTagReader. That
+# proves the decision logic. It cannot prove two things this file must prove:
+#
+#   1. GitTagReader itself — the real `git for-each-ref` / `git tag --merged` /
+#      `git rev-parse --is-shallow-repository` calls. A fake reader cannot fail
+#      the way a real git invocation fails.
+#   2. MINTER-INSENSITIVITY. The TagReader interface deliberately exposes no
+#      tagger, so a minter-sensitive guard is unrepresentable in the fake — which
+#      means the fake CANNOT demonstrate the property. Only a real annotated tag,
+#      carrying a real tagger, can. Two of the four tags that blocked a release on
+#      this fleet were the human owner's own (v1.0.1, v1.0.2 by `kirinnee`), and a
+#      minter-sensitive guard would have waved them through.
+#
+# It runs against the BUILT dist bytes, not the TypeScript sources.
+#
+# DISCIPLINE THIS SCRIPT HOLDS ITSELF TO
+#   - Every arm ASSERTS ITS OWN SUBJECT before concluding: an arm that claims
+#     "an owner-minted tag is refused" first proves the tag really is owner-minted.
+#     A setup step that silently no-ops otherwise produces a false green.
+#   - Every refusal arm is paired with a MUST-DIFFER control that goes green, so a
+#     guard that refuses unconditionally cannot pass this file.
+#   - stderr is never suppressed on a command we conclude from; it is captured and
+#     printed.
+#   - No `set -e`: it makes a guard unreachable by aborting before the check that
+#     was written to catch the failure.
+
+set -u
+
+CLI="${CLI:-}"
+if [ -z "$CLI" ]; then
+  CLI="$(cd "$(dirname "$0")/.." && pwd)/dist/semantic-generator.js"
+fi
+
+if [ ! -f "$CLI" ]; then
+  echo "FATAL: built CLI not found at $CLI — run 'pnpm build' first." >&2
+  exit 2
+fi
+
+PASS=0
+FAIL=0
+WORKROOT="$(mktemp -d)"
+trap 'rm -rf "$WORKROOT"' EXIT
+
+echo "== WF4 tag-collision guard — end-to-end proof =="
+echo "CLI under test : $CLI"
+echo "CLI bytes sha  : $(sha256sum "$CLI" | cut -d' ' -f1)"
+echo "git version    : $(git --version)"
+echo "shell          : bash $BASH_VERSION"
+echo "scratch root   : $WORKROOT"
+echo
+
+# ---------------------------------------------------------------------------
+# assertion helpers. Each prints the SUBJECT it examined, not just a verdict.
+# ---------------------------------------------------------------------------
+
+ok() {
+  PASS=$((PASS + 1))
+  echo "  PASS  $1"
+}
+
+bad() {
+  FAIL=$((FAIL + 1))
+  echo "  FAIL  $1"
+}
+
+# assert_subject <description> <actual> <expected>
+# Proves the fixture is what the arm claims it is, BEFORE the arm concludes.
+assert_subject() {
+  local what="$1" actual="$2" expected="$3"
+  if [ "$actual" = "$expected" ]; then
+    ok "SUBJECT $what == '$expected'"
+  else
+    bad "SUBJECT $what: expected '$expected', got '$actual' — fixture did not take effect, arm below proves nothing"
+  fi
+}
+
+# run_guard <repo> [version...] -> sets GUARD_RC, GUARD_OUT (stdout+stderr, whole)
+run_guard() {
+  local repo="$1"
+  shift
+  # stderr is MERGED, never discarded: the verdict is concluded from this output.
+  # Read whole; no `head`, which would race SIGPIPE.
+  GUARD_OUT="$(cd "$repo" && node "$CLI" tag-guard "$@" 2>&1)"
+  GUARD_RC=$?
+}
+
+# expect_refusal <label> <code>
+expect_refusal() {
+  local label="$1" code="$2"
+  if [ "$GUARD_RC" -eq 0 ]; then
+    bad "$label — expected refusal, got exit 0. output: $GUARD_OUT"
+    return
+  fi
+  case "$GUARD_OUT" in
+    *"$code"*) ok "$label — refused (exit $GUARD_RC) with code '$code'" ;;
+    *) bad "$label — refused (exit $GUARD_RC) but WITHOUT code '$code'. output: $GUARD_OUT" ;;
+  esac
+}
+
+# expect_clear <label> <needle>
+expect_clear() {
+  local label="$1" needle="$2"
+  if [ "$GUARD_RC" -ne 0 ]; then
+    bad "$label — expected exit 0, got $GUARD_RC. output: $GUARD_OUT"
+    return
+  fi
+  case "$GUARD_OUT" in
+    *"$needle"*) ok "$label — cleared (exit 0) saying '$needle'" ;;
+    *) bad "$label — exit 0 but output lacked '$needle'. output: $GUARD_OUT" ;;
+  esac
+}
+
+# new_repo <name> -> path, with one commit on branch `main`
+new_repo() {
+  local name="$1"
+  local d="$WORKROOT/$name"
+  mkdir -p "$d"
+  (
+    cd "$d" || exit 1
+    git init -q -b main
+    git config user.name "machine-releaser"
+    git config user.email "machine@eng.atomi.cloud"
+    git config commit.gpgsign false
+    git config tag.gpgsign false
+    echo "seed" >file.txt
+    git add file.txt
+    git commit -q -m "chore: seed"
+  )
+  echo "$d"
+}
+
+# ===========================================================================
+echo "-- ARM 1/2: a version an existing tag occupies is refused; a free one is not"
+# ===========================================================================
+R1="$(new_repo collision)"
+(cd "$R1" && git tag v1.0.0)
+assert_subject "tag v1.0.0 exists in the repo" \
+  "$(cd "$R1" && git tag --list v1.0.0)" "v1.0.0"
+
+run_guard "$R1" 1.0.0
+expect_refusal "ARM1 occupied version 1.0.0" "tag-collision"
+
+# MUST-DIFFER CONTROL. Without this, a guard hardcoded to refuse would pass ARM1.
+run_guard "$R1" 2.0.0
+expect_clear "ARM2 CONTROL free version 2.0.0" "is free"
+echo
+
+# ===========================================================================
+echo "-- ARM 3: an OWNER-MINTED annotated tag is refused (the fleet's live case)"
+# ===========================================================================
+R3="$(new_repo owner-minted)"
+(
+  cd "$R3" || exit 1
+  # Mint as the human owner, exactly as the two blocking tags were.
+  GIT_COMMITTER_NAME="kirinnee" GIT_COMMITTER_EMAIL="kirinnee@example.com" \
+    git -c user.name="kirinnee" -c user.email="kirinnee@example.com" \
+    tag -a v1.0.1 -m "release 1.0.1"
+)
+# SUBJECT: prove the tag really carries the owner as tagger. If this line fails,
+# the refusal below is about an ordinary tag and proves nothing about minters.
+assert_subject "tagger of v1.0.1" \
+  "$(cd "$R3" && git for-each-ref --format='%(taggername)' refs/tags/v1.0.1)" "kirinnee"
+assert_subject "v1.0.1 is an ANNOTATED tag object" \
+  "$(cd "$R3" && git cat-file -t "$(cd "$R3" && git rev-parse v1.0.1)")" "tag"
+
+run_guard "$R3" 1.0.1
+expect_refusal "ARM3 owner-minted (kirinnee) tag v1.0.1" "tag-collision"
+echo
+
+# ===========================================================================
+echo "-- ARM 4: a MACHINE-minted annotated tag is refused IDENTICALLY"
+# ===========================================================================
+# Paired with ARM 3 this is the actual minter-insensitivity proof: two different
+# minters, one verdict. Either arm alone would be consistent with a guard that
+# happened to care about identity.
+R4="$(new_repo machine-minted)"
+(
+  cd "$R4" || exit 1
+  GIT_COMMITTER_NAME="atomi-bot" GIT_COMMITTER_EMAIL="bot@eng.atomi.cloud" \
+    git -c user.name="atomi-bot" -c user.email="bot@eng.atomi.cloud" \
+    tag -a v1.0.1 -m "release 1.0.1"
+)
+assert_subject "tagger of v1.0.1" \
+  "$(cd "$R4" && git for-each-ref --format='%(taggername)' refs/tags/v1.0.1)" "atomi-bot"
+
+run_guard "$R4" 1.0.1
+expect_refusal "ARM4 machine-minted (atomi-bot) tag v1.0.1" "tag-collision"
+echo
+
+# ===========================================================================
+echo "-- ARM 5: a LIGHTWEIGHT tag (no tagger at all) is refused too"
+# ===========================================================================
+R5="$(new_repo lightweight)"
+(cd "$R5" && git tag v1.0.2)
+assert_subject "v1.0.2 is NOT an annotated tag object" \
+  "$(cd "$R5" && git cat-file -t "$(cd "$R5" && git rev-parse v1.0.2)")" "commit"
+assert_subject "v1.0.2 has an empty taggername" \
+  "$(cd "$R5" && git for-each-ref --format='%(taggername)' refs/tags/v1.0.2)" ""
+
+run_guard "$R5" 1.0.2
+expect_refusal "ARM5 lightweight tag v1.0.2" "tag-collision"
+echo
+
+# ===========================================================================
+echo "-- ARM 6/7: the MEASURED INCIDENT — a tag HEAD cannot reach"
+# ===========================================================================
+R6="$(new_repo unreachable)"
+(
+  cd "$R6" || exit 1
+  git checkout -q -b side
+  echo side >side.txt
+  git add side.txt
+  git commit -q -m "chore: side"
+  git tag v1.0.0
+  git checkout -q main
+)
+# SUBJECT: this is the exact condition that fooled the releaser — the reachable
+# tag set is EMPTY while the tag exists. Prove both halves.
+assert_subject "tags reachable from HEAD (the set the releaser computed from)" \
+  "$(cd "$R6" && git tag --merged HEAD | tr -d '[:space:]')" ""
+assert_subject "v1.0.0 nonetheless exists in the repository" \
+  "$(cd "$R6" && git for-each-ref --format='%(refname:strip=2)' refs/tags)" "v1.0.0"
+
+# 6: the pre-computation arm — this is what protects `sg release`, which cannot
+# know the version yet.
+run_guard "$R6"
+expect_refusal "ARM6 visibility arm, 1 tag unreachable" "tag-not-visible"
+
+# 7: the class fix — an unreachable tag still blocks its own version.
+run_guard "$R6" 1.0.0
+expect_refusal "ARM7 unreachable tag still blocks version 1.0.0" "tag-collision"
+echo
+
+# ===========================================================================
+echo "-- ARM 8: CONTROL — every version tag reachable, so the guard clears"
+# ===========================================================================
+R8="$(new_repo all-reachable)"
+(cd "$R8" && git tag v1.0.0 && git tag v1.1.0)
+assert_subject "both tags reachable from HEAD" \
+  "$(cd "$R8" && git tag --merged HEAD | sort | tr '\n' ',' | sed 's/,$//')" "v1.0.0,v1.1.0"
+
+run_guard "$R8"
+expect_clear "ARM8 CONTROL all tags reachable" "reachable from HEAD"
+echo
+
+# ===========================================================================
+echo "-- ARM 9: CONTROL — floating major/minor tags must NOT trip the guard"
+# ===========================================================================
+# semantic-release-major-tag mints `v3`/`v3.1` and MOVES them, so they are
+# routinely unreachable. Reading them as version tags would refuse every release
+# — a guard that cries wolf gets switched off, which is a way of failing.
+R9="$(new_repo floating)"
+(
+  cd "$R9" || exit 1
+  git tag v1.0.0
+  git checkout -q -b side
+  echo s >s.txt
+  git add s.txt
+  git commit -q -m "chore: s"
+  git tag v3
+  git tag v3.1
+  git checkout -q main
+)
+assert_subject "v3 and v3.1 are unreachable from HEAD" \
+  "$(cd "$R9" && git tag --merged HEAD | sort | tr '\n' ',' | sed 's/,$//')" "v1.0.0"
+
+run_guard "$R9"
+expect_clear "ARM9 CONTROL floating v3/v3.1 ignored" "reachable from HEAD"
+echo
+
+# ===========================================================================
+echo "-- ARM 10: a shallow clone REFUSES rather than reporting a clear result"
+# ===========================================================================
+R10src="$(new_repo shallow-src)"
+(
+  cd "$R10src" || exit 1
+  echo more >more.txt
+  git add more.txt
+  git commit -q -m "chore: more"
+)
+R10="$WORKROOT/shallow"
+git clone -q --depth 1 "file://$R10src" "$R10" 2>&1
+assert_subject "clone reports itself shallow" \
+  "$(cd "$R10" && git rev-parse --is-shallow-repository)" "true"
+
+run_guard "$R10" 9.9.9
+expect_refusal "ARM10 shallow clone" "shallow-clone"
+echo
+
+# ===========================================================================
+echo "-- ARM 11: 'I could not look' is not 'it is clear'"
+# ===========================================================================
+R11="$WORKROOT/not-a-repo"
+mkdir -p "$R11"
+assert_subject "directory is not a git repository" \
+  "$(cd "$R11" && git rev-parse --is-inside-work-tree 2>/dev/null || echo NOT_A_REPO)" "NOT_A_REPO"
+
+run_guard "$R11" 1.0.0
+expect_refusal "ARM11 not a git repository" "not-a-git-repo"
+echo
+
+# ===========================================================================
+echo "-- ARM 12: the v-prefix is not a way past the guard"
+# ===========================================================================
+R12="$(new_repo prefix)"
+(cd "$R12" && git tag v2.5.0)
+run_guard "$R12" 2.5.0
+expect_refusal "ARM12 bare '2.5.0' against tag 'v2.5.0'" "tag-collision"
+
+R12b="$(new_repo prefix-b)"
+(cd "$R12b" && git tag 2.6.0)
+run_guard "$R12b" v2.6.0
+expect_refusal "ARM12b 'v2.6.0' against bare tag '2.6.0'" "tag-collision"
+echo
+
+# ===========================================================================
+echo "-- ARM 13: a malformed version is refused, not guessed at"
+# ===========================================================================
+R13="$(new_repo malformed)"
+run_guard "$R13" 1.2
+expect_refusal "ARM13 '1.2' is not a full version" "invalid-version"
+echo
+
+# ===========================================================================
+# ===========================================================================
+echo "-- ARM 14: the SHIPPED BUNDLE cannot read a tag's identity at all"
+# ===========================================================================
+# ARM 3+4 prove the guard does not ACT on the minter. This arm proves it cannot
+# LEARN it: a structural check on the bytes that actually ship.
+#
+# VOCABULARY ENUMERATED (stated, because an absence claim is only as wide as its
+# word list, and two engines agreeing on one pattern controls for a matcher bug
+# and NOT for whether the pattern spans the concept):
+#   taggername  taggeremail  taggerdate  tagger
+#   committername  committeremail  committerdate
+#   creator  creatordate
+#   authorname  authoremail
+# These are git ref-format tokens. The subject is deliberately the TOKEN SET and
+# not English words: the guard's own refusal message legitimately contains the
+# words "author" and "minted", so an English-word sweep would report a false hit
+# and, worse, invite someone to delete the explanation to make the check pass.
+IDENT_TOKENS="taggername taggeremail taggerdate tagger committername committeremail committerdate creator creatordate authorname authoremail"
+
+# SUBJECT: the whole emitted tree, NOT the entry file.
+#
+# The first draft of this arm scanned "$CLI" alone and printed a confident PASS.
+# The must-differ control below caught it: `tsc` does not bundle. It emits 40
+# separate .js files and dist/semantic-generator.js is a 2.9 KB entry point that
+# only requires the others — the guard's actual bytes live in
+# dist/classLibrary/release/tag-guard.js. Scanning the entry file for a token
+# that lives in a sibling module examines nothing and always passes. That is the
+# inert-check shape this fleet has hit eleven times tonight, and it survived
+# writing precisely because its output looked like the answer.
+DIST_DIR="$(dirname "$CLI")"
+DIST_FILE_COUNT="$(find "$DIST_DIR" -name '*.js' -type f | wc -l)"
+
+BUNDLE_HITS=""
+for tok in $IDENT_TOKENS; do
+  # -F: fixed string, so no metachar in the token can silently widen or narrow
+  # the match. stderr merged; we conclude from this.
+  if grep -rFql "$tok" "$DIST_DIR" 2>&1; then
+    BUNDLE_HITS="$BUNDLE_HITS $tok"
+  fi
+done
+if [ -n "$BUNDLE_HITS" ]; then
+  bad "ARM14 shipped tree CAN read tag identity — tokens present:$BUNDLE_HITS"
+else
+  ok "ARM14 shipped tree ($DIST_FILE_COUNT .js files under $DIST_DIR) contains none of the $(echo "$IDENT_TOKENS" | wc -w) tag-identity tokens ($IDENT_TOKENS)"
+fi
+
+# MUST-DIFFER CONTROL for ARM14. Without it, a typo in the loop, an unreadable
+# path, or an empty token list would print the same reassuring PASS while having
+# examined nothing. Assert the SAME instrument, over the SAME population, finds a
+# token that IS there. This control has already earned its place once: it caught
+# the wrong-subject draft described above.
+if grep -rFql "for-each-ref" "$DIST_DIR" 2>&1; then
+  ok "ARM14 CONTROL the same grep over the same tree DOES find 'for-each-ref' (instrument is live)"
+else
+  bad "ARM14 CONTROL grep found neither identity tokens NOR 'for-each-ref' — the check examined nothing and its PASS above is meaningless"
+fi
+echo
+
+echo "== RESULT =="
+echo "arms passed : $PASS"
+echo "arms failed : $FAIL"
+if [ "$FAIL" -ne 0 ]; then
+  echo "VERDICT: FAILED"
+  exit 1
+fi
+echo "VERDICT: ALL PASS"

--- a/sabotage/wf4-tag-collision-guard.sh
+++ b/sabotage/wf4-tag-collision-guard.sh
@@ -385,6 +385,64 @@ else
 fi
 echo
 
+# ===========================================================================
+echo "-- ARM 15: the guard is WIRED INTO 'sg release', not merely available"
+# ===========================================================================
+# Everything above tests `sg tag-guard`, the standalone command. That is not the
+# path that protects a release. This arm exercises the PRODUCTION path: the
+# preflight inside `sg release`, which is what actually stands between a repo and
+# a committed-release-with-no-tag.
+#
+# A guard that is shipped, correct, tested and NOT WIRED IN is an inert check.
+R15="$(new_repo release-preflight)"
+(
+  cd "$R15" || exit 1
+  git checkout -q -b side
+  echo s >s.txt
+  git add s.txt
+  git commit -q -m "chore: s"
+  git tag v1.0.0
+  git checkout -q main
+)
+assert_subject "tags reachable from HEAD" \
+  "$(cd "$R15" && git tag --merged HEAD | tr -d '[:space:]')" ""
+
+# stderr merged; `sg release` writes the refusal to stderr.
+REL_OUT="$(cd "$R15" && node "$CLI" release 2>&1)"
+REL_RC=$?
+if [ "$REL_RC" -eq 0 ]; then
+  bad "ARM15 'sg release' did NOT refuse (exit 0) — the guard is not wired into the release path"
+else
+  case "$REL_OUT" in
+    *tag-not-visible*) ok "ARM15 'sg release' refused at preflight (exit $REL_RC) with 'tag-not-visible'" ;;
+    *) bad "ARM15 'sg release' exited $REL_RC but NOT via the tag guard. output: $REL_OUT" ;;
+  esac
+fi
+
+# MUST-DIFFER CONTROL. Merge the tag into HEAD and the preflight must let the
+# release THROUGH — it then fails on the next thing (a missing config), which is
+# a DIFFERENT failure. Without this arm, a `sg release` that was simply broken
+# for any unrelated reason would satisfy the arm above.
+(cd "$R15" && git merge -q --no-edit side)
+assert_subject "tag reachable after merge" \
+  "$(cd "$R15" && git tag --merged HEAD | tr -d '[:space:]')" "v1.0.0"
+
+REL_OUT2="$(cd "$R15" && node "$CLI" release 2>&1)"
+case "$REL_OUT2" in
+  *"tag-guard OK"*)
+    case "$REL_OUT2" in
+      *atomi_release.yaml*)
+        ok "ARM15 CONTROL preflight PASSED and release proceeded to a different failure (missing config), proving the refusal above was the guard and not a broken command"
+        ;;
+      *)
+        ok "ARM15 CONTROL preflight passed (guard cleared) once every tag was reachable"
+        ;;
+    esac
+    ;;
+  *) bad "ARM15 CONTROL preflight did not clear even with every tag reachable. output: $REL_OUT2" ;;
+esac
+echo
+
 echo "== RESULT =="
 echo "arms passed : $PASS"
 echo "arms failed : $FAIL"

--- a/src/classLibrary/release/tag-guard.ts
+++ b/src/classLibrary/release/tag-guard.ts
@@ -1,0 +1,333 @@
+import execa from "execa";
+import { Err, Ok, Result } from "@hqoss/monads";
+import { PR, PromiseResult } from "../resultUtil";
+
+/**
+ * Stable machine-readable identifiers for every refusal. Part of the CLI
+ * contract: CI and hooks grep for them.
+ */
+const GuardCode = {
+  NotAGitRepo: "not-a-git-repo",
+  ShallowClone: "shallow-clone",
+  InvalidVersion: "invalid-version",
+  TagCollision: "tag-collision",
+  TagNotVisible: "tag-not-visible",
+} as const;
+
+type GuardCode = (typeof GuardCode)[keyof typeof GuardCode];
+
+/** `1.2.3`, `v1.2.3`, `v1.2.3-rc.1`, `1.2.3+build.4`. */
+const FULL_VERSION = /^v?(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/;
+
+interface SemVer {
+  raw: string;
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease: string;
+}
+
+function parseVersion(tag: string): SemVer | null {
+  const m = FULL_VERSION.exec(tag);
+  if (m == null) return null;
+  const dash = tag.indexOf("-");
+  return {
+    raw: tag,
+    major: Number(m[1]),
+    minor: Number(m[2]),
+    patch: Number(m[3]),
+    prerelease: dash >= 0 ? tag.slice(dash + 1) : "",
+  };
+}
+
+function compareVersion(a: SemVer, b: SemVer): number {
+  if (a.major !== b.major) return a.major - b.major;
+  if (a.minor !== b.minor) return a.minor - b.minor;
+  if (a.patch !== b.patch) return a.patch - b.patch;
+  // A release outranks its own prereleases; beyond that, lexical is enough for
+  // the only question asked here ("is anything unreachable at least as high").
+  if (a.prerelease === b.prerelease) return 0;
+  if (a.prerelease === "") return 1;
+  if (b.prerelease === "") return -1;
+  return a.prerelease < b.prerelease ? -1 : 1;
+}
+
+/**
+ * Reads tag *names* from a repository.
+ *
+ * Deliberately exposes no way to read a tag's tagger, committer, date or
+ * message. The guard must refuse a colliding tag REGARDLESS OF WHO MINTED IT:
+ * of the four tags that blocked a release on this fleet, two were the human
+ * owner's, and a minter-sensitive guard would have waved them through. Keeping
+ * identity out of the interface makes that failure unrepresentable rather than
+ * merely unwritten.
+ */
+interface TagReader {
+  /** Every tag in the repository, reachable or not. */
+  All(): Promise<Result<string[], string>>;
+
+  /** Only the tags reachable from `HEAD` — what semantic-release can see. */
+  Visible(): Promise<Result<string[], string>>;
+
+  /** `false` unless the working copy is a shallow clone. */
+  IsShallow(): Promise<Result<boolean, string>>;
+}
+
+class GitTagReader implements TagReader {
+  private readonly cwd: string;
+
+  constructor(cwd: string) {
+    this.cwd = cwd;
+  }
+
+  private async git(args: string[]): Promise<Result<string, string>> {
+    try {
+      // stderr is captured and returned, never discarded: the caller concludes
+      // from this result and a swallowed message turns a refusal into silence.
+      const { stdout } = await execa("git", args, { cwd: this.cwd });
+      return Ok(stdout.toString());
+    } catch (e) {
+      const detail =
+        e != null && typeof e === "object" && "stderr" in e
+          ? String((e as { stderr: unknown }).stderr).trim()
+          : String(e);
+      return Err(detail.length > 0 ? detail : String(e));
+    }
+  }
+
+  private static lines(out: string): string[] {
+    return out
+      .split("\n")
+      .map((x) => x.trim())
+      .filter((x) => x.length > 0);
+  }
+
+  async All(): Promise<Result<string[], string>> {
+    // for-each-ref, not `git tag --list`: it takes no implicit reachability
+    // filter and returns names only.
+    const r = await this.git([
+      "for-each-ref",
+      "--format=%(refname:strip=2)",
+      "refs/tags",
+    ]);
+    return r.map(GitTagReader.lines);
+  }
+
+  async Visible(): Promise<Result<string[], string>> {
+    const r = await this.git(["tag", "--merged", "HEAD"]);
+    return r.map(GitTagReader.lines);
+  }
+
+  async IsShallow(): Promise<Result<boolean, string>> {
+    const r = await this.git(["rev-parse", "--is-shallow-repository"]);
+    return r.map((x) => x.trim() === "true");
+  }
+}
+
+interface GuardFinding {
+  code: GuardCode;
+  message: string;
+}
+
+function render(f: GuardFinding): string {
+  return `${f.code}: ${f.message}`;
+}
+
+/**
+ * Refuses to compute a release onto a version a tag already occupies.
+ *
+ * The hazard this closes, measured: `git tag --merged <branch>` returned **0**
+ * tags, so the releaser computed `1.0.0` from scratch — while the repository
+ * already carried `v1.0.0` and ten further v-tags on other refs. The three
+ * parts of the hazard were a tag validation that checked only the NAME and not
+ * existence, a tag creation with no `-f`, and tagging that happens AFTER the
+ * release commit. Failure mode: the release commit lands, the changelog is
+ * written, assets are committed — and only *then* does tag creation fail,
+ * leaving a committed release with no tag on the branch about to be pushed.
+ *
+ * The instance was cleared by deleting four tags. This is the class fix.
+ */
+class TagGuard {
+  private readonly reader: TagReader;
+
+  constructor(reader: TagReader) {
+    this.reader = reader;
+  }
+
+  /**
+   * Refuses when the repository holds version tags that `HEAD` cannot reach.
+   *
+   * This is the arm that catches the measured incident, and it runs without
+   * knowing the version yet — which is the only thing that can be checked
+   * *before* semantic-release computes one.
+   */
+  CheckVisibility(): PromiseResult<string, string[]> {
+    return PR(async (): Promise<Result<string, string[]>> => {
+      const pre = await this.preflight();
+      if (pre.isErr()) return Err(pre.unwrapErr());
+      const { all, visible } = pre.unwrap();
+
+      const allVersions = all
+        .map(parseVersion)
+        .filter((x): x is SemVer => x != null);
+      const visibleSet = new Set(visible);
+      const invisible = allVersions.filter((v) => !visibleSet.has(v.raw));
+
+      if (invisible.length === 0) {
+        return Ok(
+          `all ${allVersions.length} version tag(s) are reachable from HEAD; the computed version cannot land on an existing tag`,
+        );
+      }
+
+      const highest = invisible.reduce((a, b) =>
+        compareVersion(a, b) >= 0 ? a : b,
+      );
+      return Err([
+        render({
+          code: GuardCode.TagNotVisible,
+          message:
+            `${invisible.length} version tag(s) exist in this repository but are NOT reachable from HEAD ` +
+            `(highest: ${highest.raw}; all: ${invisible
+              .map((x) => x.raw)
+              .join(", ")}). ` +
+            `The next version is computed from reachable tags only, so it can be computed onto one of these. ` +
+            `Tag creation happens after the release commit, so the commit and changelog would land and only then would tagging fail, ` +
+            `leaving a committed release with no tag. Fetch the tags into this branch's history, or delete the tags deliberately, before releasing.`,
+        }),
+      ]);
+    });
+  }
+
+  /**
+   * Refuses when a tag for `version` already exists anywhere in the repository
+   * — reachable or not, annotated or lightweight, whoever created it.
+   */
+  CheckVersion(version: string): PromiseResult<string, string[]> {
+    return PR(async (): Promise<Result<string, string[]>> => {
+      const parsed = parseVersion(version);
+      if (parsed == null) {
+        return Err([
+          render({
+            code: GuardCode.InvalidVersion,
+            message: `\`${version}\` is not a full version (expected \`x.y.z\`, optionally \`v\`-prefixed); refusing rather than guessing what to check`,
+          }),
+        ]);
+      }
+
+      const pre = await this.preflight();
+      if (pre.isErr()) return Err(pre.unwrapErr());
+      const { all } = pre.unwrap();
+
+      const bare = version.startsWith("v") ? version.slice(1) : version;
+      const candidates = [bare, `v${bare}`];
+      const taken = all.filter((t) => candidates.includes(t));
+
+      if (taken.length > 0) {
+        return Err([
+          render({
+            code: GuardCode.TagCollision,
+            message:
+              `tag(s) ${taken.join(", ")} already exist in this repository, so version ${bare} is already taken. ` +
+              `Existence is the only test applied: the tag's author, date, annotation and reachability are not consulted, ` +
+              `because a tag minted by a human owner blocks a release exactly as hard as one minted by a machine.`,
+          }),
+        ]);
+      }
+
+      return Ok(
+        `version ${bare} is free (checked ${candidates.join(" and ")} against all ${all.length} tag(s) in the repository)`,
+      );
+    });
+  }
+
+  /** Both arms. Every finding is reported, not just the first. */
+  Check(version?: string): PromiseResult<string[], string[]> {
+    return PR(async (): Promise<Result<string[], string[]>> => {
+      const results: string[] = [];
+      const errors: string[] = [];
+
+      if (version != null) {
+        const r = await this.CheckVersion(version).promise;
+        r.match({
+          ok: (o) => results.push(o),
+          err: (e) => errors.push(...e),
+        });
+      }
+
+      const v = await this.CheckVisibility().promise;
+      v.match({
+        ok: (o) => results.push(o),
+        err: (e) => errors.push(...e),
+      });
+
+      // Both arms share a preflight, so a repository-level fault (shallow clone,
+      // not a repository) is reported by each of them. Report it once: a reason
+      // repeated reads as two independent faults.
+      if (errors.length > 0) return Err([...new Set(errors)]);
+      return Ok(results);
+    });
+  }
+
+  /**
+   * Establishes that the guard is able to answer at all.
+   *
+   * A guard that cannot read the tags must refuse, not pass: "I could not look"
+   * and "I looked and it is clear" are different verdicts, and only one of them
+   * is safe to release on.
+   */
+  private async preflight(): Promise<
+    Result<{ all: string[]; visible: string[] }, string[]>
+  > {
+    const shallow = await this.reader.IsShallow();
+    if (shallow.isErr()) {
+      return Err([
+        render({
+          code: GuardCode.NotAGitRepo,
+          message: `cannot inspect tags: ${shallow.unwrapErr()}`,
+        }),
+      ]);
+    }
+    if (shallow.unwrap()) {
+      return Err([
+        render({
+          code: GuardCode.ShallowClone,
+          message:
+            "this is a shallow clone, so the tag set is incomplete and a collision cannot be ruled out. " +
+            "Refusing instead of reporting a clear result from an incomplete population. " +
+            "Fetch full history and tags (`git fetch --unshallow --tags`) before releasing.",
+        }),
+      ]);
+    }
+
+    const all = await this.reader.All();
+    if (all.isErr()) {
+      return Err([
+        render({
+          code: GuardCode.NotAGitRepo,
+          message: `cannot list tags: ${all.unwrapErr()}`,
+        }),
+      ]);
+    }
+
+    const visible = await this.reader.Visible();
+    if (visible.isErr()) {
+      return Err([
+        render({
+          code: GuardCode.NotAGitRepo,
+          message: `cannot list tags reachable from HEAD: ${visible.unwrapErr()}`,
+        }),
+      ]);
+    }
+
+    return Ok({ all: all.unwrap(), visible: visible.unwrap() });
+  }
+}
+
+export {
+  TagGuard,
+  GitTagReader,
+  TagReader,
+  GuardCode,
+  parseVersion,
+  compareVersion,
+};

--- a/src/controllers/release-controller.ts
+++ b/src/controllers/release-controller.ts
@@ -18,6 +18,7 @@ import {
   VersionManager,
 } from "../classLibrary/release/verison-manager";
 import { None, Option, Some } from "@hqoss/monads";
+import { GitTagReader, TagGuard } from "../classLibrary/release/tag-guard";
 
 export function ToInstaller(s?: string): Option<Installer> {
   return Wrap(s).andThen((x) => {
@@ -94,6 +95,20 @@ export function ReleaseController(core: Core, c: Command): void {
           versionManager,
           cwd,
         );
+        // Tag-collision preflight, before anything is computed or written.
+        // It runs unconditionally and has no bypass flag: releasing onto a
+        // version an existing tag occupies lands the release commit and
+        // changelog and only then fails to tag, leaving a committed release
+        // with no tag on the branch about to be pushed.
+        const guard = await new TagGuard(
+          new GitTagReader(cwd),
+        ).CheckVisibility().promise;
+        if (guard.isErr()) {
+          guard.unwrapErr().forEach((w) => console.error(`tag-guard: ${w}`));
+          process.exit(1);
+        }
+        console.log(`tag-guard OK: ${guard.unwrap()}`);
+
         console.log("Default packages: ", versionManager.defaultPackages);
         const r = await reader
           .Read(configPath)

--- a/src/controllers/tag-guard-controller.ts
+++ b/src/controllers/tag-guard-controller.ts
@@ -1,0 +1,35 @@
+import { Command } from "commander";
+import * as path from "path";
+import { GitTagReader, TagGuard } from "../classLibrary/release/tag-guard";
+
+export function TagGuardController(c: Command): void {
+  // The version is a positional argument, not `--version`: on a commander
+  // subcommand a `--version` option is shadowed by the program's own
+  // `-V, --version`, which prints the CLI version and exits 0. A guard that
+  // exits 0 without checking anything is worse than no guard.
+  c.description(
+    "Refuse to release onto a version an existing tag already occupies, regardless of who minted the tag.",
+  )
+    .arguments("[version]")
+    .option("--cwd <dir>", "repository to inspect. default: .")
+    .action(async function (
+      version: string | undefined,
+      opts: {
+        [s: string]: string;
+      },
+    ) {
+      const cwd = path.resolve(opts.cwd ?? ".");
+      const guard = new TagGuard(new GitTagReader(cwd));
+
+      const r = await guard.Check(version).promise;
+      r.match({
+        // stderr, never suppressed: the release verdict is concluded from this.
+        err: (e) => {
+          console.error(`tag-guard REFUSED: ${e.length} reason(s)`);
+          e.forEach((w) => console.error(`  ${w}`));
+          process.exit(1);
+        },
+        ok: (o) => o.forEach((w) => console.log(`tag-guard OK: ${w}`)),
+      });
+    });
+}

--- a/src/semantic-generator.ts
+++ b/src/semantic-generator.ts
@@ -6,6 +6,7 @@ import * as process from "process";
 import { ReleaseController } from "./controllers/release-controller";
 import { GitlintController } from "./controllers/gitlint-controller";
 import { CommitterController } from "./controllers/committer-controller";
+import { TagGuardController } from "./controllers/tag-guard-controller";
 
 const core: Core = new Kore();
 core.ExtendPrimitives();
@@ -30,6 +31,9 @@ program
 
 const release = program.command("release");
 ReleaseController(core, release);
+
+const tagGuard = program.command("tag-guard");
+TagGuardController(tagGuard);
 
 const gitlint = program.command("gitlint");
 GitlintController(core, gitlint);

--- a/tests/release/tag-guard.spec.ts
+++ b/tests/release/tag-guard.spec.ts
@@ -1,0 +1,228 @@
+import { Err, Ok, Result } from "@hqoss/monads";
+import { should } from "chai";
+import {
+  compareVersion,
+  GuardCode,
+  parseVersion,
+  TagGuard,
+  TagReader,
+} from "../../src/classLibrary/release/tag-guard";
+
+should();
+
+/**
+ * A tag reader that can be told exactly what a repository holds.
+ *
+ * It also RECORDS every call, so a test can assert the guard consulted the full
+ * tag set rather than the reachable subset — the distinction the measured
+ * incident turned on.
+ */
+class FakeTagReader implements TagReader {
+  readonly calls: string[] = [];
+
+  constructor(
+    private readonly all: string[],
+    private readonly visible: string[] = all,
+    private readonly shallow = false,
+    private readonly broken: string | null = null,
+  ) {}
+
+  async All(): Promise<Result<string[], string>> {
+    this.calls.push("All");
+    if (this.broken != null) return Err(this.broken);
+    return Ok(this.all);
+  }
+
+  async Visible(): Promise<Result<string[], string>> {
+    this.calls.push("Visible");
+    if (this.broken != null) return Err(this.broken);
+    return Ok(this.visible);
+  }
+
+  async IsShallow(): Promise<Result<boolean, string>> {
+    this.calls.push("IsShallow");
+    if (this.broken != null) return Err(this.broken);
+    return Ok(this.shallow);
+  }
+}
+
+async function version(
+  reader: TagReader,
+  v: string,
+): Promise<[boolean, string[]]> {
+  const r = await new TagGuard(reader).CheckVersion(v).promise;
+  return r.isOk() ? [true, [r.unwrap()]] : [false, r.unwrapErr()];
+}
+
+async function visibility(reader: TagReader): Promise<[boolean, string[]]> {
+  const r = await new TagGuard(reader).CheckVisibility().promise;
+  return r.isOk() ? [true, [r.unwrap()]] : [false, r.unwrapErr()];
+}
+
+describe("parseVersion", () => {
+  it("accepts full versions with and without a v prefix", () => {
+    parseVersion("1.2.3")?.major.should.equal(1);
+    parseVersion("v1.2.3")?.patch.should.equal(3);
+    parseVersion("v1.2.3-rc.1")?.prerelease.should.equal("rc.1");
+  });
+
+  it("rejects anything that is not a full version", () => {
+    // Floating major/minor tags (semantic-release-major-tag mints `v3`, `v3.1`
+    // and MOVES them) must not be read as version tags, or every release would
+    // refuse itself.
+    ["v3", "v3.1", "1.2", "main", "latest", "release-1.2.3", "", "v"].forEach(
+      (t) => {
+        // eslint-disable-next-line no-unused-expressions
+        (parseVersion(t) === null).should.equal(
+          true,
+          `expected null for '${t}'`,
+        );
+      },
+    );
+  });
+});
+
+describe("compareVersion", () => {
+  it("orders by major, minor, patch", () => {
+    const c = (a: string, b: string) =>
+      compareVersion(parseVersion(a)!, parseVersion(b)!);
+    c("2.0.0", "1.9.9").should.be.greaterThan(0);
+    c("1.3.1", "1.3.0").should.be.greaterThan(0);
+    c("1.0.0", "1.0.0").should.equal(0);
+  });
+
+  it("ranks a release above its own prereleases", () => {
+    compareVersion(
+      parseVersion("1.0.0")!,
+      parseVersion("1.0.0-rc.1")!,
+    ).should.be.greaterThan(0);
+  });
+});
+
+describe("TagGuard.CheckVersion", () => {
+  // ── the must-differ control ────────────────────────────────────────────────
+  it("clears a version no tag occupies", async () => {
+    const [ok, msgs] = await version(new FakeTagReader(["v1.0.0"]), "2.0.0");
+    ok.should.equal(true, msgs.join("; "));
+    msgs[0].should.contain("is free");
+  });
+
+  it("refuses a version whose tag exists", async () => {
+    const [ok, msgs] = await version(new FakeTagReader(["v1.0.0"]), "1.0.0");
+    ok.should.equal(false);
+    msgs.join(";").should.contain(GuardCode.TagCollision);
+    msgs.join(";").should.contain("v1.0.0");
+  });
+
+  it("refuses regardless of the v prefix on either side", async () => {
+    (await version(new FakeTagReader(["2.0.0"]), "v2.0.0"))[0].should.equal(
+      false,
+    );
+    (await version(new FakeTagReader(["v2.0.0"]), "2.0.0"))[0].should.equal(
+      false,
+    );
+  });
+
+  it("refuses a tag that HEAD cannot reach, not only the reachable ones", async () => {
+    // The measured incident in one assertion: the tag exists, `git tag --merged`
+    // cannot see it, and the guard must still refuse. A guard that consulted
+    // only the reachable set would return OK here.
+    const reader = new FakeTagReader(["v1.0.0"], []);
+    const [ok, msgs] = await version(reader, "1.0.0");
+    ok.should.equal(false, "an unreachable tag must still block its version");
+    msgs.join(";").should.contain(GuardCode.TagCollision);
+    reader.calls.should.contain("All");
+  });
+
+  it("refuses a version that is not full semver rather than guessing", async () => {
+    const [ok, msgs] = await version(new FakeTagReader([]), "1.2");
+    ok.should.equal(false);
+    msgs.join(";").should.contain(GuardCode.InvalidVersion);
+  });
+
+  it("refuses when the tag set is incomplete, instead of reporting it clear", async () => {
+    const [ok, msgs] = await version(new FakeTagReader([], [], true), "9.9.9");
+    ok.should.equal(false, "a shallow clone cannot clear a version");
+    msgs.join(";").should.contain(GuardCode.ShallowClone);
+  });
+
+  it("refuses when it cannot read the repository at all", async () => {
+    const [ok, msgs] = await version(
+      new FakeTagReader([], [], false, "fatal: not a git repository"),
+      "1.0.0",
+    );
+    ok.should.equal(false, "'I could not look' is not 'it is clear'");
+    msgs.join(";").should.contain(GuardCode.NotAGitRepo);
+  });
+});
+
+describe("TagGuard.CheckVisibility", () => {
+  // ── the must-differ control ────────────────────────────────────────────────
+  it("clears a repository whose every version tag is reachable", async () => {
+    const [ok, msgs] = await visibility(
+      new FakeTagReader(["v1.0.0", "v1.1.0"], ["v1.0.0", "v1.1.0"]),
+    );
+    ok.should.equal(true, msgs.join("; "));
+    msgs[0].should.contain("reachable from HEAD");
+  });
+
+  it("reproduces the measured incident: 11 tags in the repo, 0 reachable", async () => {
+    const all = [
+      "v0.1.0",
+      "v0.1.1",
+      "v1.0.0",
+      "v1.0.1",
+      "v1.0.2",
+      "v1.1.0",
+      "v1.1.1",
+      "v1.1.2",
+      "v1.2.0",
+      "v1.3.0",
+      "v1.3.1",
+    ];
+    const [ok, msgs] = await visibility(new FakeTagReader(all, []));
+    ok.should.equal(false);
+    const joined = msgs.join(";");
+    joined.should.contain(GuardCode.TagNotVisible);
+    joined.should.contain("11 version tag(s)");
+    joined.should.contain("highest: v1.3.1");
+  });
+
+  it("ignores floating major and minor tags, which move by design", async () => {
+    // `v3` and `v3.1` are unreachable in this repository, but they are not
+    // version tags; treating them as such would refuse every release.
+    const [ok] = await visibility(
+      new FakeTagReader(["v1.0.0", "v3", "v3.1"], ["v1.0.0"]),
+    );
+    ok.should.equal(true);
+  });
+
+  it("ignores non-version refs entirely", async () => {
+    const [ok] = await visibility(
+      new FakeTagReader(["v1.0.0", "latest", "release-candidate"], ["v1.0.0"]),
+    );
+    ok.should.equal(true);
+  });
+
+  it("refuses on a shallow clone", async () => {
+    const [ok, msgs] = await visibility(new FakeTagReader([], [], true));
+    ok.should.equal(false);
+    msgs.join(";").should.contain(GuardCode.ShallowClone);
+  });
+});
+
+describe("TagGuard.Check", () => {
+  it("reports a repository-level fault once, not once per arm", async () => {
+    const r = await new TagGuard(new FakeTagReader([], [], true)).Check("1.0.0")
+      .promise;
+    r.isErr().should.equal(true);
+    r.unwrapErr().length.should.equal(1);
+  });
+
+  it("runs the visibility arm even when no version is supplied", async () => {
+    const r = await new TagGuard(new FakeTagReader(["v1.0.0"], [])).Check()
+      .promise;
+    r.isErr().should.equal(true);
+    r.unwrapErr().join(";").should.contain(GuardCode.TagNotVisible);
+  });
+});


### PR DESCRIPTION
## WF4 (collision guard half) — the releaser refuses to compute onto an existing tag

Enforces the WF4 **COLLISION GUARD**. Independent of the WF4 bump-type work; it is the guard
half only.

**Base branch is `local-install`, not `master`.** `master` is a one-commit skeleton (`437b890`,
version `0.0.1`, `src/` = `Rectangle.ts`/`Shape.ts`/`Square.ts`). `local-install` is the live
line: 127 commits, `merge-base(master, local-install) == 437b890`, version `0.11.0` — matching
the published npm `latest`.

### The live incident behind this

- `git tag --merged <branch>` returned **0** tags, so the releaser computed **`1.0.0`**.
- The repository already carried **`v1.0.0`** plus ten further v-tags
  (`v0.1.0 v0.1.1 v1.0.1 v1.0.2 v1.1.0 v1.1.1 v1.1.2 v1.2.0 v1.3.0 v1.3.1`) on refs the
  release branch could not reach.

The hazard triple: **`validateTag` name-only**, **`createTag` no-`-f`**, and
**tag-after-commit**. So the failure mode is not "the release stops" — the release commit lands,
the changelog is written, assets are committed, and *only then* does tagging fail, leaving **a
committed release with no tag** on the branch about to be pushed.

That instance was cleared by deleting four tags (the whole recurrence path v1.0.0→v1.3.1
verified clear). **The INSTANCE closed and the CLASS stayed open. This is the class fix.**

### What this adds

`sg tag-guard [version] [--cwd <dir>]`, plus the same guard as a **mandatory preflight inside
`sg release`** — before the version is computed, before the config is even read, with **no
bypass flag**.

| arm | question | when it can run |
| --- | --- | --- |
| `CheckVersion` | is *this* version's tag already taken? | when a concrete version is in hand |
| `CheckVisibility` | does the repo hold version tags `HEAD` cannot reach? | always, including before a version exists |

Refusal codes: `tag-collision`, `tag-not-visible`, `invalid-version`, `shallow-clone`,
`not-a-git-repo`.

### "Regardless of who minted it" is structural, not conventional

Two of the four tags that blocked the fleet were the **human owner's**, so a minter-sensitive
guard would have waved them through. The `TagReader` interface exposes `All()`, `Visible()` and
`IsShallow()` and **no way to read a tagger, committer, date or message** — a minter-sensitive
guard is unrepresentable rather than merely un-written. `All()` uses `git for-each-ref
refs/tags`, not `git tag --list`, because it applies no implicit reachability filter.

### Refusing is the right answer to "I could not check"

`shallow-clone` and `not-a-git-repo` are **refusals, not skips**. A guard returning `0` when it
could not read the tag set reports *safe* having measured nothing — the inert-check shape.

### Deliberately not treated as version tags

`semantic-release-major-tag` mints floating `v3` / `v3.1` and **moves** them, so they are
unreachable from `HEAD` roughly whenever they were just moved. Counting them as version tags
would make every release refuse itself. Only `x.y.z` (optionally `v`-prefixed, optionally with
a prerelease/build suffix) counts.

---

## Sabotage proof — every arm demonstrated able to fail

**Scope of the control.** shell: `bash` under `direnv exec .` in this repo's nix dev shell ·
binary: `dist/semantic-generator` rebuilt by `pls build` from the **committed** bytes of
`0d40af4` · population: throwaway git repositories under a temp root, one per arm, each arm
printing the repository it used · **no arm touches `diene.all`, any `wave5/*` branch, any node
tree, or this repo's own tags, and nothing is ever deleted from a real repository.** Every arm
asserts its setup actually landed (`SETUP NO-OP … arm is vacuous` is reported as a failure)
because a setup step that silently no-ops produces a false green.

```text
== ARM 1 (must-differ control): a FREE version proceeds
  repo: /tmp/sg-tagguard-KKUvxj/free  tags: []
    | tag-guard OK: version 9.9.9 is free (checked 9.9.9 and v9.9.9 against all 0 tag(s) in the repository)
    | tag-guard OK: all 0 version tag(s) are reachable from HEAD; the computed version cannot land on an existing tag
  PASS: rc=0 on a free version
== ARM 2: a MACHINE-minted lightweight tag blocks its own version
  repo: /tmp/sg-tagguard-KKUvxj/machine-tag  tags: [v1.0.0 ]
    | tag-guard REFUSED: 1 reason(s)
    |   tag-collision: tag(s) v1.0.0 already exist in this repository, so version 1.0.0 is already taken. Existence is the only test applied: the tag's author, date, annotation and reachability are not consulted, because a tag minted by a human owner blocks a release exactly as hard as one minted by a machine.
  PASS: rc=1
== ARM 3: an OWNER-MINTED ANNOTATED tag blocks it just as hard
   (two of the four tags that blocked this fleet were the human owner's;
    a minter-sensitive guard would have waved them through)
  repo: /tmp/sg-tagguard-KKUvxj/owner-tag  tags: [v1.2.0 ]  tagger: Ernest Ng <owner@example.invalid>
  PASS: tag really was minted by a different identity (Ernest Ng <owner@example.invalid> != fleet-machine)
    | tag-guard REFUSED: 1 reason(s)
    |   tag-collision: tag(s) v1.2.0 already exist in this repository, so version 1.2.0 is already taken. Existence is the only test applied: the tag's author, date, annotation and reachability are not consulted, because a tag minted by a human owner blocks a release exactly as hard as one minted by a machine.
  PASS: rc=1
== ARM 4: prefix insensitivity - an UNPREFIXED tag blocks the v-prefixed ask and vice versa
  repo: /tmp/sg-tagguard-KKUvxj/prefix  tags: [2.0.0 v3.0.0 ]
    | tag-guard REFUSED: 1 reason(s)
    |   tag-collision: tag(s) 2.0.0 already exist in this repository, so version 2.0.0 is already taken. Existence is the only test applied: the tag's author, date, annotation and reachability are not consulted, because a tag minted by a human owner blocks a release exactly as hard as one minted by a machine.
  PASS: v2.0.0 refused by tag 2.0.0 (rc=1)
    | tag-guard REFUSED: 1 reason(s)
    |   tag-collision: tag(s) v3.0.0 already exist in this repository, so version 3.0.0 is already taken. Existence is the only test applied: the tag's author, date, annotation and reachability are not consulted, because a tag minted by a human owner blocks a release exactly as hard as one minted by a machine.
  PASS: 3.0.0 refused by tag v3.0.0 (rc=1)
== ARM 5: THE MEASURED INCIDENT - tags unreachable from HEAD, so the
   computed version would land on one. `git tag --merged HEAD` sees ZERO.
  repo: /tmp/sg-tagguard-KKUvxj/invisible  tags in repo: 11   tags reachable from HEAD: 0
  PASS: incident reproduced exactly: 11 tags in the repo, 0 reachable from HEAD
    | tag-guard REFUSED: 1 reason(s)
    |   tag-not-visible: 11 version tag(s) exist in this repository but are NOT reachable from HEAD (highest: v1.3.1; all: v0.1.0, v0.1.1, v1.0.0, v1.0.1, v1.0.2, v1.1.0, v1.1.1, v1.1.2, v1.2.0, v1.3.0, v1.3.1). The next version is computed from reachable tags only, so it can be computed onto one of these. Tag creation happens after the release commit, so the commit and changelog would land and only then would tagging fail, leaving a committed release with no tag. Fetch the tags into this branch's history, or delete the tags deliberately, before releasing.
  PASS: rc=1 with no --version at all
== ARM 5b (must-differ control for arm 5): merge the tags into HEAD -> GREEN
  repo: /tmp/sg-tagguard-KKUvxj/invisible  tags reachable from HEAD after merge: 11
    | tag-guard OK: all 11 version tag(s) are reachable from HEAD; the computed version cannot land on an existing tag
  PASS: rc=0 once every tag is reachable
   ... and a version that IS taken is still refused in the same repo:
    | tag-guard REFUSED: 1 reason(s)
    |   tag-collision: tag(s) v1.3.1 already exist in this repository, so version 1.3.1 is already taken. Existence is the only test applied: the tag's author, date, annotation and reachability are not consulted, because a tag minted by a human owner blocks a release exactly as hard as one minted by a machine.
  PASS: rc=1
== ARM 6: the guard CANNOT VERIFY -> it refuses, it does not report 'clear'
  repo: /tmp/sg-tagguard-KKUvxj/shallow  is-shallow: true
  PASS: clone really is shallow
    | tag-guard REFUSED: 1 reason(s)
    |   shallow-clone: this is a shallow clone, so the tag set is incomplete and a collision cannot be ruled out. Refusing instead of reporting a clear result from an incomplete population. Fetch full history and tags (`git fetch --unshallow --tags`) before releasing.
  PASS: rc=1
== ARM 7: NOT A GIT REPO -> refuses with a named reason, never 'safe'
    | tag-guard REFUSED: 1 reason(s)
    |   not-a-git-repo: cannot inspect tags: fatal: not a git repository (or any of the parent directories): .git
  PASS: rc=1
== ARM 8: a MALFORMED version is refused rather than silently skipped
    | tag-guard REFUSED: 1 reason(s)
    |   invalid-version: `1.2` is not a full version (expected `x.y.z`, optionally `v`-prefixed); refusing rather than guessing what to check
  PASS: rc=1
== ARM 9: the guard is WIRED INTO `sg release`, not merely available
  repo: /tmp/sg-tagguard-KKUvxj/release-preflight  tags: [v1.0.0 ]  reachable: 0
    | tag-guard: tag-not-visible: 1 version tag(s) exist in this repository but are NOT reachable from HEAD (highest: v1.0.0; all: v1.0.0). The next version is computed from reachable tags only, so it can be computed onto one of these. Tag creation happens after the release commit, so the commit and changelog would land and only then would tagging fail, leaving a committed release with no tag. Fetch the tags into this branch's history, or delete the tags deliberately, before releasing.
  PASS: rc=1
   ... and the must-differ control: with every tag reachable, `sg release`
       gets PAST the preflight and fails on the next thing instead.
    | tag-guard OK: all 1 version tag(s) are reachable from HEAD; the computed version cannot land on an existing tag
    | Default packages:  [
    |   'semantic-release@23.0.1',
    |   'conventional-changelog-conventionalcommits@7.0.2',
    |   '@semantic-release/commit-analyzer@12.0.0',
    |   '@semantic-release/release-notes-generator@12.0.0'
    | ]
    | ENOENT: no such file or directory, open 'atomi_release.yaml'
  PASS: rc=1
== ARM 10: the SHIPPED BYTES consult no minter identity
  scope: 40 compiled .js files under /home/kirin/Workspace/wt-sg-wf4-tagguard/dist (not just the entry file -
         the entry module cannot contain these tokens, so grepping it alone
         would have been a control scoped to the wrong subject)
  PASS: no minter/identity or reachability-filter token in the shipped bundle
  PASS: positive control: shipped bundle contains 'for-each-ref'
  PASS: positive control: shipped bundle contains 'refname:strip=2'
  PASS: positive control: shipped bundle contains 'is-shallow-repository'
  PASS: positive control: shipped bundle contains 'tag-collision'
  PASS: positive control: shipped bundle contains 'tag-not-visible'
SABOTAGE PROOF: ALL ARMS PASSED (0 failures)
```

Two findings the harness produced about **my own first attempt**, both fixed in this PR:

1. **`--version` as a subcommand option is an inert guard.** Commander resolves it against the
   program's own `-V, --version`, so `sg tag-guard --version 1.0.0` printed `0.11.0` and exited
   **0** — checking nothing while looking like a pass. Arms 2, 3, 4, 6, 7 and 8 all went red and
   caught it. The version is now a **positional argument**.
2. **My ARM 10 grep was scoped to the wrong subject.** It grepped `dist/semantic-generator.js`
   alone — the entry module, which *cannot* contain the tokens being searched for. The paired
   **positive control** ("the bundle must contain `for-each-ref`") failed and exposed it. It now
   greps all 40 compiled `.js` files under `dist/`.

Neither would have been visible from a green run. They are in the PR because the acceptance bar
is "demonstrate every check able to fail", not "the check passed".

### Permanent regression coverage

`tests/release/tag-guard.spec.ts` — 18 arms, including:

- **must-differ controls on both arms** (a free version clears; a fully-reachable repo clears).
  Without them, a guard that refused unconditionally would pass every other arm.
- the measured incident as a unit test (11 tags, 0 reachable, `highest: v1.3.1`);
- an unreachable tag still blocking its own version, asserting the guard consulted `All` and not
  the reachable subset;
- floating `v3` / `v3.1` and non-version refs ignored;
- a repository-level fault reported **once**, not once per arm.

Local suite: **77 passing** (base commit: 59 — the 18 new arms), **3 failing**.

## What I could not verify, stated plainly

- **CI cannot run on this repository, pre-existing and not caused by this PR.**
  `.github/workflows/ci.yaml` targets the retired `ubuntu-20.04` runner and installs its
  environment from `./ci-env.old-nix`, **a file absent from the entire tree**. Both jobs fail at
  *Install Environment* on the base commit too. All verification here is **local**, in this
  repo's nix dev shell. Repairing that workflow is a separate change.
- **The 3 failing tests are pre-existing and untouched.** `tests/release/configuration.spec.ts`
  asserts ANSI colour escapes from `ReleaseConfigurationValid`; chalk emits none off-TTY, so
  they fail identically on the base commit (base 59/3 → here 77/3). The guard deliberately does
  not route findings through chalk.
- **The pre-commit hook could not run via `git commit`.** The committed
  `.pre-commit-config.yaml` symlinks to
  `/nix/store/1pajyl2p5ijpa66j3hwvx1vp8f0hi14n-pre-commit-config.json`, which does **not exist**
  on this machine. The hooks were run directly against the changed files instead — Secrets
  Scanning ×2, Shell Check, treefmt, `tsc-lint`, `ts-lint` all pass — and `gitlint` was run
  against the commit message (clean). Committed with `--no-verify` for that reason alone; the
  environment-specific symlink churn was **not** committed.
- **Not verified: behaviour against a real remote's tag set on a fetch-limited CI checkout.**
  The `shallow-clone` refusal is proved on a real `--depth 1` clone, but I did not exercise a
  CI job that fetches tags partially in some other way. If a pipeline fetches with
  `fetch-depth: 0` but *without* `--tags`, `All()` sees fewer tags than the remote holds and the
  guard would clear a version the remote has taken. That is a genuine residual gap and belongs
  to whoever wires release CI.
- No matrix was used or needed; the matrix moratorium is untouched.

## Independence

Independently mergeable. No dependency on PR #2 (config-lint) or on WF3's `release.yaml`
rename; touches no file PR #2 touches except `src/semantic-generator.ts`, where the two add
adjacent-but-distinct command registrations — if both land, git merges them cleanly, and either
one alone is complete. Adds `docs/developer/05-…` where PR #2 adds `04-…`, so no filename
collision in either order. **Do not merge on my account — this is for the owner.**


---

# CONTINUATION (rhonda, `msgok2x1-b5942264`)

dedric hit his account limit. I continued this branch rather than restarting it. Everything above is
his and stands; this section is what changed since `0d40af4`.

## The gap I closed: the proof was not re-runnable

The sabotage proof above was **real and correct** — but it existed only as **pasted output in this
PR description**. The harness itself was never committed. That means a reviewer cannot re-derive it,
and it has **zero regression value**: nothing re-runs when the guard changes.

It is now committed as **`sabotage/wf4-tag-collision-guard.sh` + `.out`** — **32 arms**, run against
the built `dist` bytes on real throwaway git repositories. It supersedes the pasted transcript as the
authoritative proof, and it re-derives dedric's arms rather than trusting them.

## Demonstrated able to fail — by injection, not by accident (STRONG)

dedric's arms were shown able to go red *incidentally*, by catching two of his own bugs. That is good
evidence but it is not a repeatable control. I injected a defect deliberately:

**Injection:** a filter in `GitTagReader.All()` that drops tags whose tagger is `kirinnee` — i.e.
exactly the minter-sensitive guard the requirement forbids.

| arm | verdict under injection |
|---|---|
| ARM 3 (owner-minted `kirinnee`) | **RED** — guard reported `version 1.0.1 is free`, the exact live failure mode |
| ARM 4 (machine-minted `atomi-bot`) | GREEN — unaffected |
| ARM 14 (shipped-tree token scan) | **RED** — independently, on structure rather than behaviour |

**ARM 4 staying green while ARM 3 goes red is the point.** It proves the pair discriminates
minter-sensitivity specifically, rather than the suite being generally sensitive to any change.

Source restored byte-identically afterwards: sha `eff027ac…` verified against the pre-injection
backup, and `git status` confirmed the working tree matched `HEAD` with no modification.

## ARM 15 — new: the guard is wired into `sg release`, not merely shipped

Everything else tests `sg tag-guard`, the standalone command. That is **not the path that protects a
release**. ARM 15 exercises the preflight inside `sg release` itself, with a must-differ control that
merges the tag into `HEAD` and asserts the release then gets **past** the preflight and fails on a
*different* thing (missing config). Without that control, an `sg release` broken for any unrelated
reason would satisfy the arm.

*(dedric's ARM 9 covered this in the transcript; it is now committed code.)*

## An independent rediscovery worth recording

My first draft of ARM 14 scanned `dist/semantic-generator.js` alone and printed a confident PASS
having examined nothing — `tsc` does not bundle; it emits ~40 files and the entry point is a ~2.9 KB
require shim. Its **must-differ control** ("the same grep over the same population must still find
`for-each-ref`") caught it immediately.

**dedric hit the identical bug in his ARM 10 and had already fixed it.** I did not know, because that
finding lived in this PR description and not in his handoff notes. Two people, same trap, same night.
It is now recorded in `docs/developer/05-Tag Guard.md` so the third person does not pay for it.

ARM 14 also **states its vocabulary in the claim** — 11 git ref-format identity tokens, listed — on
the principle that an absence claim is only as wide as its word list, and that running one pattern
through two engines controls for a matcher bug rather than for whether the pattern spans the concept.

## Design note verified across five vocabularies

The release path calls **only `CheckVisibility()`**, never `CheckVersion()`. Confirmed by sweeping
`CheckVersion`, `CheckVisibility`, `.Check(`, `TagGuard` and `tag-collision` — five distinct terms,
not one pattern through two tools.

This is **correct by design**: at release time the version has not been computed, so `CheckVersion`
has nothing to check. It does mean the visibility arm is load-bearing for the whole release path, and
its soundness rests on: *if every version tag is reachable from `HEAD`, the computed next version is
strictly greater than all of them and cannot collide.*

**Deliberately NOT loosened.** Refusing on *any* unreachable version tag — rather than only those
above the highest reachable one — is over-strict, and I considered narrowing it. I did not, because
the narrowing is **unsound** where the repo's `tagFormat` admits fewer tags than the guard's parser:
a bare `1.5.0` alongside `tagFormat: v${version}` would raise the computed ceiling while
semantic-release still released `v1.1.0` onto an existing tag. A guard that cries wolf can be argued
with; a guard with a hole cannot be trusted.

## Verification status (this section supersedes the counts above)

- Suite **77 passing / 3 failing**. Base `e34031a` is **59 / 3** → **+18 arms, zero new failures.**
- `shellcheck` clean on the harness. `gitlint` clean on all three commits.
- `prettier --check` clean on the doc. **Note:** it failed on the doc at `0d40af4` too, so that fix
  is included here rather than attributed to this change.

## COULD NOT VERIFY — additions to dedric's list

- **`shfmt` is UNVERIFIED on the harness.** It is not on `PATH` in this devshell (it comes from the
  treefmt nix wrapper), and `treefmt` itself aborts with *"treefmt.toml could not be found in … and
  up"*. The script is **shellcheck-clean only**. I am not claiming it is treefmt-clean.
- **Real-git coverage of `GitTagReader` lives in `sabotage/`, not in `pnpm test`.** The mocha suite
  drives a `FakeTagReader` throughout. A regression in the real reader would not be caught by
  `pnpm test` alone, and since CI is dead on this repo, nothing runs the harness automatically.
- **CI remains pre-existing dead** and this PR does not fix it. A red check here is not a verdict on
  this change.

## Not merged

I have merged nothing and will merge nothing. The owner merges. Base `local-install`; independently
mergeable and safe to merge out of order.
