### PR TITLE
sg conventions --check (D9 enforcement) + -c/--config for renamed configs (D6/WF3)

### DIFF
--- a/docs/developer/03-Commit Conventions.md
+++ b/docs/developer/03-Commit Conventions.md
@@ -41,11 +41,11 @@ Fixed a bug within the repository
 | example         | fix: dropdown flickering                                           |
 | example applied | when this commit is applied, it will _fix_ **dropdown flickering** |
 
-| Scope    | Description                                | Bump    |
-| -------- | ------------------------------------------ | ------- |
-| default  | Generic fixes not under `drv` or `patch`   | `patch` |
-| `drv`    | Fixes in nix derivations in the repository | `patch` |
-| `config` | Fixes in configuration                     | `nil`   |
+| Scope    | Description                                    | Bump    |
+| -------- | ---------------------------------------------- | ------- |
+| default  | Generic fixes not under `drv` or `patch`       | `patch` |
+| `drv`    | Fixes in old-nix derivations in the repository | `patch` |
+| `config` | Fixes in configuration                         | `nil`   |
 
 ## new
 
@@ -115,7 +115,7 @@ Update configuration of the repository
 | `lint`   | Add, update or remove linters                                                | `nil` |
 | `fmt`    | Add, updatge or remove formatters                                            | `nil` |
 | `build`  | Add, update or change buyild pipelines and generators                        | `nil` |
-| `nix`    | Add, update or change nix shell                                              | `nil` |
+| `nix`    | Add, update or change old-nix shell                                          | `nil` |
 | `env`    | Add, update or change environment                                            | `nil` |
 | `ignore` | Add, update or change ignore configurations                                  | `nil` |
 

--- a/sabotage/conventions-check.out
+++ b/sabotage/conventions-check.out
@@ -1,0 +1,387 @@
+sabotage/conventions-check.sh
+repo   : /home/kirin/Workspace/wt-sg-conventions-check
+HEAD   : a2f2fc6f8341261fc446612f75706b3e34d1dce9
+subject: sg conventions --check   (D9: generated docs are regenerate-only)
+config : atomi_release.yaml
+doc    : docs/developer/03-Commit Conventions.md
+
+==============================================================================
+P1  the arms will run against COMMITTED bytes
+==============================================================================
+  subject of this control: the working tree status of src/, tests/,
+  atomi_release.yaml and the generated doc. .pre-commit-config.yaml is
+  deliberately OUT of scope: it is a /nix/store symlink that this machine
+  rewrites on every direnv load and that is never committed.
+  PASS  P1 subject paths are clean; HEAD == what the arms will read
+
+==============================================================================
+P2  rebuild dist/ from the committed source
+==============================================================================
+  --- command output (whole, unpiped) ------------------------------------
+  | task: [clean:build] rm -rf dist
+  | task: [build] tsc
+  | task: [build] sd var___INJECT_VERSION___ $(cat package.json | jq .version | sd \" '') dist/semantic-generator.js
+  ------------------------------------------------------------------------
+  PASS  P2 build exited 0 and produced /home/kirin/Workspace/wt-sg-conventions-check/dist/semantic-generator.js
+
+==============================================================================
+P3  the rebuilt dist/ actually contains the new code
+==============================================================================
+  subject: the FILES tsc emitted under dist/, named individually.
+  tsc does NOT bundle -- dist/semantic-generator.js is a small require
+  shim -- so a structural grep over the entry file alone examines almost
+  nothing and would pass unconditionally. These are the emitted modules
+  this feature consists of.
+  present: dist/controllers/conventions-controller.js
+  present: dist/classLibrary/release/conventions-checker.js
+  present: dist/classLibrary/lineDiff.js
+  PASS  P3 all 3 expected emitted modules exist under dist/
+  files mentioning 'ConventionsChecker' (population: every file under dist/): 2
+
+==============================================================================
+P4  --check and --config are on the SUBCOMMAND'S OWN parser
+==============================================================================
+  subject: the help commander itself emits for 'conventions', not the
+  program-level help. A flag silently swallowed by an outer parser exits
+  0 and checks nothing -- the way a subcommand --version is shadowed by
+  the program-level -V, --version.
+  --- command output (whole, unpiped) ------------------------------------
+  | Usage: Semantic Generator conventions [options]
+  | 
+  | Generate the commit convention document from the release configuration
+  | 
+  | Options:
+  |   -c, --config <cfg>  path to configuration. default: atomi_release.yaml
+  |   --check             do not write; verify the document on disk matches the
+  |                       generated one and exit 1 if it does not
+  |   -h, --help          display help for command
+  ------------------------------------------------------------------------
+  PASS  P4 'conventions --help' exits 0
+  PASS  P4 commander lists --check on the conventions subcommand
+  PASS  P4 commander lists --config on the conventions subcommand
+
+==============================================================================
+A1  GREEN ARM  -- committed doc vs committed config
+==============================================================================
+  doc sha256: bcf6b4ef1858027173fcd407b8a3a65bfdbc1b1badcd67b108905da472c26829
+  --- command output (whole, unpiped) ------------------------------------
+  | docs/developer/03-Commit Conventions.md is up to date with atomi_release.yaml
+  ------------------------------------------------------------------------
+  exit code : 0
+  PASS  A1 committed bytes pass the check (exit 0)
+
+==============================================================================
+A2  RED ARM  -- hand-edit the doc BODY (the real historical drift)
+==============================================================================
+  subject: the 'fix' scope table row inside the generated doc.
+  The edit reintroduces the exact drift a076d18 left in this repo for two
+  years: config says 'old-nix derivations', doc said 'nix derivations'.
+  PASS  A2 precondition: the needle is present, so the edit cannot no-op
+  doc sha256 before: bcf6b4ef1858027173fcd407b8a3a65bfdbc1b1badcd67b108905da472c26829
+  doc sha256 after : 6531f4463c68f1f14f3e71770149f169336359997886f739487fe3d6243e0679
+  PASS  A2 MUTATION ASSERTED: the bytes on disk actually changed
+  --- command output (whole, unpiped) ------------------------------------
+  | docs/developer/03-Commit Conventions.md does not match the document generated from atomi_release.yaml.
+  | 
+  | docs/developer/03-Commit Conventions.md is a GENERATED file: it is produced from the "conventionMarkdown"
+  | section of atomi_release.yaml and is regenerate-only. Hand-edits are not allowed.
+  | 
+  | To fix: change atomi_release.yaml, run "sg conventions", and commit the result.
+  | 
+  | --- expected: regenerated from atomi_release.yaml
+  | +++ actual:   docs/developer/03-Commit Conventions.md on disk
+  | @@ -44,7 +44,7 @@
+  |  | Scope    | Description                                    | Bump    |
+  |  | -------- | ---------------------------------------------- | ------- |
+  |  | default  | Generic fixes not under `drv` or `patch`       | `patch` |
+  | -| `drv`    | Fixes in old-nix derivations in the repository | `patch` |
+  | +| `drv`    | Fixes in nix derivations in the repository | `patch` |
+  |  | `config` | Fixes in configuration                         | `nil`   |
+  |  
+  |  ## new
+  ------------------------------------------------------------------------
+  exit code : 1
+  PASS  A2 hand-edited doc is REJECTED (exit 1)
+  PASS  A2 the diff names both sides of the edit
+  PASS  A2 the failure states the rule and a runnable remedy
+
+==============================================================================
+A3  RED ARM  -- one whitespace byte appended to the doc
+==============================================================================
+  subject: the final byte of the generated doc. This separates a
+  byte-exact comparison from a trimmed/normalised one.
+  doc bytes before: 5649   after: 5650
+  PASS  A3 MUTATION ASSERTED: exactly one byte longer, sha changed
+  --- command output (whole, unpiped) ------------------------------------
+  | docs/developer/03-Commit Conventions.md does not match the document generated from atomi_release.yaml.
+  | 
+  | docs/developer/03-Commit Conventions.md is a GENERATED file: it is produced from the "conventionMarkdown"
+  | section of atomi_release.yaml and is regenerate-only. Hand-edits are not allowed.
+  | 
+  | To fix: change atomi_release.yaml, run "sg conventions", and commit the result.
+  | 
+  | --- expected: regenerated from atomi_release.yaml
+  | +++ actual:   docs/developer/03-Commit Conventions.md on disk
+  | @@ -132,3 +132,4 @@
+  |  | Scope        | Description                    | Bump  |
+  |  | ------------ | ------------------------------ | ----- |
+  |  | `no-release` | Prevent release from happening | `nil` |
+  | +
+  ------------------------------------------------------------------------
+  exit code : 1
+  PASS  A3 a whitespace-only hand-edit is REJECTED (exit 1)
+
+==============================================================================
+A4  RED ARM  -- the doc is missing entirely
+==============================================================================
+  subject: the existence of the generated doc.
+  PASS  A4 MUTATION ASSERTED: the doc is gone from the sandbox
+  --- command output (whole, unpiped) ------------------------------------
+  | cannot read docs/developer/03-Commit Conventions.md: ENOENT: no such file or directory, open '/tmp/tmp.h1qSLiEdWg/a4/docs/developer/03-Commit Conventions.md'
+  | 
+  | docs/developer/03-Commit Conventions.md is a GENERATED file: it is produced from the "conventionMarkdown"
+  | section of atomi_release.yaml and is regenerate-only. Hand-edits are not allowed.
+  | 
+  | To fix: change atomi_release.yaml, run "sg conventions", and commit the result.
+  ------------------------------------------------------------------------
+  exit code : 1
+  PASS  A4 a missing doc is REJECTED (exit 1)
+
+==============================================================================
+A5  RED ARM  -- drift on the CONFIG side, doc untouched
+==============================================================================
+  subject: atomi_release.yaml. The doc keeps its committed bytes; the config
+  gains a scope. This is the direction real drift took in a076d18, and it
+  proves the check regenerates from the config rather than comparing the
+  doc to a stored copy of itself.
+  anchor '^      config:$' occurrences in the config: 1
+  PASS  A5 precondition: exactly one anchor line, so the injection is unambiguous
+  config sha256 before: 7df730db2172121a29aade3050b302ecfb4565a3cfe6009edde3ccbe4e677ece
+  config sha256 after : d0ebe77674134b2b4157c9944adf79441ab6cfb148349360b8077b14782e0e4d
+  doc    sha256 before: bcf6b4ef1858027173fcd407b8a3a65bfdbc1b1badcd67b108905da472c26829
+  doc    sha256 after : bcf6b4ef1858027173fcd407b8a3a65bfdbc1b1badcd67b108905da472c26829
+  PASS  A5 MUTATION ASSERTED: the config bytes changed
+  PASS  A5 CONTROL: the doc was NOT touched, so only the config moved
+  --- command output (whole, unpiped) ------------------------------------
+  | docs/developer/03-Commit Conventions.md does not match the document generated from atomi_release.yaml.
+  | 
+  | docs/developer/03-Commit Conventions.md is a GENERATED file: it is produced from the "conventionMarkdown"
+  | section of atomi_release.yaml and is regenerate-only. Hand-edits are not allowed.
+  | 
+  | To fix: change atomi_release.yaml, run "sg conventions", and commit the result.
+  | 
+  | --- expected: regenerated from atomi_release.yaml
+  | +++ actual:   docs/developer/03-Commit Conventions.md on disk
+  | @@ -41,12 +41,11 @@
+  |  | example         | fix: dropdown flickering                                           |
+  |  | example applied | when this commit is applied, it will _fix_ **dropdown flickering** |
+  |  
+  | -| Scope            | Description                                    | Bump    |
+  | -| ---------------- | ---------------------------------------------- | ------- |
+  | -| default          | Generic fixes not under `drv` or `patch`       | `patch` |
+  | -| `drv`            | Fixes in old-nix derivations in the repository | `patch` |
+  | -| `sabotage-scope` | injected by the sabotage harness               | `nil`   |
+  | -| `config`         | Fixes in configuration                         | `nil`   |
+  | +| Scope    | Description                                    | Bump    |
+  | +| -------- | ---------------------------------------------- | ------- |
+  | +| default  | Generic fixes not under `drv` or `patch`       | `patch` |
+  | +| `drv`    | Fixes in old-nix derivations in the repository | `patch` |
+  | +| `config` | Fixes in configuration                         | `nil`   |
+  |  
+  |  ## new
+  |  
+  ------------------------------------------------------------------------
+  exit code : 1
+  PASS  A5 a doc left stale by a config change is REJECTED (exit 1)
+  PASS  A5 the diff names the scope that was added to the config
+
+==============================================================================
+A6  NON-MUTATION CONTROL  -- rewrite the doc with IDENTICAL bytes
+==============================================================================
+  subject: the discrimination of the check itself. If A2/A3/A4 went red
+  merely because the file had been written to, this arm would go red too
+  and the red arms above would carry no information.
+  doc sha256 before: bcf6b4ef1858027173fcd407b8a3a65bfdbc1b1badcd67b108905da472c26829
+  doc sha256 after : bcf6b4ef1858027173fcd407b8a3a65bfdbc1b1badcd67b108905da472c26829
+  PASS  A6 NON-MUTATION ASSERTED: the file was rewritten, bytes identical
+  --- command output (whole, unpiped) ------------------------------------
+  | docs/developer/03-Commit Conventions.md is up to date with atomi_release.yaml
+  ------------------------------------------------------------------------
+  exit code : 0
+  PASS  A6 an identical rewrite is ACCEPTED (exit 0) -- the check reads content
+
+==============================================================================
+A7  READ-ONLY CONTROL  -- --check must not repair the file
+==============================================================================
+  subject: the doc's bytes across a failing --check run. A check that
+  silently rewrites the file would go green on the second CI run and
+  hide the violation instead of reporting it.
+  --- command output (whole, unpiped) ------------------------------------
+  | docs/developer/03-Commit Conventions.md does not match the document generated from atomi_release.yaml.
+  | 
+  | docs/developer/03-Commit Conventions.md is a GENERATED file: it is produced from the "conventionMarkdown"
+  | section of atomi_release.yaml and is regenerate-only. Hand-edits are not allowed.
+  | 
+  | To fix: change atomi_release.yaml, run "sg conventions", and commit the result.
+  | 
+  | --- expected: regenerated from atomi_release.yaml
+  | +++ actual:   docs/developer/03-Commit Conventions.md on disk
+  | @@ -132,3 +132,5 @@
+  |  | Scope        | Description                    | Bump  |
+  |  | ------------ | ------------------------------ | ----- |
+  |  | `no-release` | Prevent release from happening | `nil` |
+  | +
+  | +hand written paragraph
+  ------------------------------------------------------------------------
+  exit code : 1
+  doc sha256 before check: f5ffe3dccf7d96592ec0571cbd29abefb64900c6ce08e94fe6d0681d9c2fbfef
+  doc sha256 after  check: f5ffe3dccf7d96592ec0571cbd29abefb64900c6ce08e94fe6d0681d9c2fbfef
+  PASS  A7 the tampered doc is REJECTED (exit 1)
+  PASS  A7 --check left the file byte-identical
+
+==============================================================================
+A8  UNREADABLE-CONFIG CONTROL  -- must not pass when it cannot read
+==============================================================================
+  subject: the -c flag pointed at a path that does not exist. A checker
+  that exits 0 when its input is missing reports 'safe' for the wrong
+  reason -- the single most common way a guard turns inert.
+  PASS  A8 precondition: the config path really is absent
+  --- command output (whole, unpiped) ------------------------------------
+  | ENOENT: no such file or directory, open 'definitely-not-here.yaml'
+  ------------------------------------------------------------------------
+  exit code : 1
+  PASS  A8 an unreadable config is REJECTED (exit 1)
+
+==============================================================================
+A9  REMEDY ARM  -- 'sg conventions' repairs what --check rejects
+==============================================================================
+  subject: the doc's bytes before and after the remedy command. D9's
+  remedy has to be a runnable command; if it were not, the only way to
+  clear the check would be the hand-edit D9 forbids.
+  PASS  A9 MUTATION ASSERTED: the doc no longer matches the committed bytes
+  --check before remedy exit: 1
+  --- command output (whole, unpiped) ------------------------------------
+  | regenerated docs/developer/03-Commit Conventions.md from atomi_release.yaml
+  ------------------------------------------------------------------------
+  write exit code : 0
+  doc sha256 committed : bcf6b4ef1858027173fcd407b8a3a65bfdbc1b1badcd67b108905da472c26829
+  doc sha256 tampered  : f5ffe3dccf7d96592ec0571cbd29abefb64900c6ce08e94fe6d0681d9c2fbfef
+  doc sha256 after 'sg conventions' : bcf6b4ef1858027173fcd407b8a3a65bfdbc1b1badcd67b108905da472c26829
+  --- command output (whole, unpiped) ------------------------------------
+  | docs/developer/03-Commit Conventions.md is up to date with atomi_release.yaml
+  ------------------------------------------------------------------------
+  --check after remedy exit: 0
+  PASS  A9 the tampered doc was RED before the remedy
+  PASS  A9 'sg conventions' restored the exact committed bytes
+  PASS  A9 --check is GREEN after the remedy
+
+==============================================================================
+B1  WRITE ARM  -- renamed config (the WF3 end state), doc absent
+==============================================================================
+  subject: docs/developer/03-Commit Conventions.md as an OUTPUT. The
+  sandbox holds release.yaml and no atomi_release.yaml at all.
+  The exit code is not the finding here; the file appearing is.
+  PASS  B1 precondition: the old config name is absent from the sandbox
+  PASS  B1 precondition: the doc does not exist before the run
+  --- command output (whole, unpiped) ------------------------------------
+  | regenerated docs/developer/03-Commit Conventions.md from release.yaml
+  ------------------------------------------------------------------------
+  exit code : 0
+  doc sha256 written   : bcf6b4ef1858027173fcd407b8a3a65bfdbc1b1badcd67b108905da472c26829
+  doc sha256 committed : bcf6b4ef1858027173fcd407b8a3a65bfdbc1b1badcd67b108905da472c26829
+  PASS  B1 MUTATION ASSERTED: the doc did not exist before and exists now
+  PASS  B1 the written bytes are identical to the committed doc
+  PASS  B1 'conventions -c release.yaml' exits 0 on the WF3 end state
+
+==============================================================================
+B2  WRITE ARM, NEGATIVE  -- -c points at a config that is not there
+==============================================================================
+  subject: the -c path on the WRITE path specifically. Without this the
+  B1 exit 0 cannot be told apart from a command that ignores -c.
+  PASS  B2 precondition: nope.yaml really is absent
+  --- command output (whole, unpiped) ------------------------------------
+  | ENOENT: no such file or directory, open 'nope.yaml'
+  ------------------------------------------------------------------------
+  exit code : 1
+  PASS  B2 a missing config is REJECTED on the write path (exit 1)
+  PASS  B2 the failure names the config path it could not read
+  PASS  B2 NON-MUTATION ASSERTED: nothing was written on the failing path
+
+==============================================================================
+B3  WRITE DISCRIMINATOR  -- BOTH config names present, -c must decide
+==============================================================================
+  subject: which of two present configs the write path actually read.
+  B1 and B2 together still cannot separate 'read release.yaml' from
+  'ignored -c and found atomi_release.yaml anyway', because in a sandbox
+  holding only one config both behaviours look identical. Here both
+  names exist; only release.yaml carries the marker.
+  PASS  B3 MUTATION ASSERTED: the marker is in release.yaml
+  PASS  B3 CONTROL: the marker is absent from atomi_release.yaml, so it discriminates
+  PASS  B3 precondition: BOTH config names are present in the sandbox
+  --- command output (whole, unpiped) ------------------------------------
+  | regenerated docs/developer/03-Commit Conventions.md from release.yaml
+  ------------------------------------------------------------------------
+  exit code : 0
+  PASS  B3 the write succeeded and produced a file
+  PASS  B3 the written doc carries the marker -- -c release.yaml WAS read
+
+==============================================================================
+B4  CHECK DISCRIMINATOR  -- --check must honour -c too
+==============================================================================
+  subject: which of two present configs --check regenerated from. The
+  doc on disk is the committed one, which matches atomi_release.yaml exactly.
+  If --check ignored -c it would read atomi_release.yaml and go GREEN. Honouring
+  -c means regenerating from the marked release.yaml and going RED.
+  PASS  B4 precondition: the doc on disk is byte-identical to the committed doc
+  CONTROL, --check -c atomi_release.yaml (the UNMARKED config) exit: 0
+  PASS  B4 CONTROL: against the unmarked config the same doc is GREEN
+  --- command output (whole, unpiped) ------------------------------------
+  | docs/developer/03-Commit Conventions.md does not match the document generated from release.yaml.
+  | 
+  | docs/developer/03-Commit Conventions.md is a GENERATED file: it is produced from the "conventionMarkdown"
+  | section of release.yaml and is regenerate-only. Hand-edits are not allowed.
+  | 
+  | To fix: change release.yaml, run "sg conventions", and commit the result.
+  | 
+  | --- expected: regenerated from release.yaml
+  | +++ actual:   docs/developer/03-Commit Conventions.md on disk
+  | @@ -45,7 +45,7 @@
+  |  | -------- | ---------------------------------------------- | ------- |
+  |  | default  | Generic fixes not under `drv` or `patch`       | `patch` |
+  |  | `drv`    | Fixes in old-nix derivations in the repository | `patch` |
+  | -| `config` | MARKER-ONLY-IN-RELEASE-YAML                    | `nil`   |
+  | +| `config` | Fixes in configuration                         | `nil`   |
+  |  
+  |  ## new
+  |  
+  ------------------------------------------------------------------------
+  exit code : 1
+  PASS  B4 --check -c release.yaml is RED -- it regenerated from the named config
+  PASS  B4 the diff names the marker that exists only in release.yaml
+  PASS  B4 --check left the doc byte-identical, as on the A-series
+
+==============================================================================
+SUMMARY
+==============================================================================
+  population: 4 preflight controls (P1-P4), 9 D9 arms (A1-A9) and 4
+  config-flag arms (B1-B4), run against the committed bytes of HEAD with
+  a dist/ rebuilt from that same source.
+  assertions executed: 50
+  passed: 50
+  failed: 0
+
+  RESULT: every arm behaved as specified.
+
+  D9 half (--check refuses a stale generated doc). Shown ABLE TO GO RED
+  on four distinct sabotages -- doc body, doc trailing byte, missing
+  doc, config-side drift -- each with the sabotage itself asserted to
+  have landed, and ABLE TO STAY GREEN on a byte-identical rewrite.
+  STRONG.
+
+  D6/WF3 half (-c reads a renamed config). Shown to WRITE on the
+  renamed end state with the written bytes asserted, to go RED on a
+  missing config without writing anything, and -- with BOTH config
+  names present and only the named one marked -- to follow the marker
+  on the write path and on the check path. That last pair is what
+  separates 'read my config' from 'ignored my flag and found
+  atomi_release.yaml anyway'. STRONG.

--- a/sabotage/conventions-check.sh
+++ b/sabotage/conventions-check.sh
@@ -1,0 +1,707 @@
+#!/usr/bin/env bash
+#
+# Sabotage harness for `sg conventions --check` (enforces D9: releaser-generated
+# docs are regenerate-only).
+#
+# WHAT THIS PROVES, AND WHAT IT DOES NOT
+# --------------------------------------
+# A check that has never been shown to go red is a candidate, not a control.
+# Every arm below therefore does two separate things:
+#
+#   1. asserts the SABOTAGE ITSELF LANDED  (sha256 / byte length / existence
+#      changed in the direction intended), because a setup step that silently
+#      no-ops produces a false green; and
+#   2. only then reads the check's verdict.
+#
+# The subject of every arm is named in its banner: which file, which bytes,
+# which side of the config/doc pair.
+#
+# The arms run against the COMMITTED bytes of HEAD (materialised with
+# `git show HEAD:<path>` into a throwaway sandbox) driven by a dist/ REBUILT
+# from that same committed source. Nothing here reads the dirty worktree.
+#
+# Usage:  bash sabotage/conventions-check.sh
+# Writes: sabotage/conventions-check.out  (and the same text to stdout)
+# Exit:   0 iff every arm behaved as specified.
+
+set -u
+set -o pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CLI="$ROOT/dist/semantic-generator.js"
+CONFIG_REL="atomi_release.yaml"
+DOC_REL="docs/developer/03-Commit Conventions.md"
+OUT_FILE="$ROOT/sabotage/conventions-check.out"
+
+WORK=""
+CHECK_EC=0
+
+pass=0
+fail=0
+
+banner() {
+  echo
+  echo "=============================================================================="
+  echo "$*"
+  echo "=============================================================================="
+}
+
+ok() {
+  echo "  PASS  $*"
+  pass=$((pass + 1))
+}
+
+bad() {
+  echo "  FAIL  $*"
+  fail=$((fail + 1))
+}
+
+sha() {
+  sha256sum "$1" | cut -d' ' -f1
+}
+
+size() {
+  wc -c <"$1" | tr -d ' '
+}
+
+# Materialise a sandbox holding ONLY the two files the command reads, taken
+# from the committed tree at HEAD.
+new_sandbox() {
+  new_sandbox_named "$1" "$CONFIG_REL" with-doc
+}
+
+# As above, but the config is written under an arbitrary name (so the WF3
+# end state, where the config is renamed, can be staged) and the generated doc
+# is optional.
+new_sandbox_named() {
+  local name="$1" cfgname="$2" withdoc="$3"
+  local dir="$WORK/$name"
+  rm -rf "$dir"
+  mkdir -p "$dir/$(dirname "$DOC_REL")"
+  git -C "$ROOT" show "HEAD:$CONFIG_REL" >"$dir/$cfgname"
+  if [ "$withdoc" = "with-doc" ]; then
+    git -C "$ROOT" show "HEAD:$DOC_REL" >"$dir/$DOC_REL"
+  fi
+  echo "$dir"
+}
+
+run_write_args() {
+  local sb="$1" out="$2"
+  shift 2
+  (cd "$sb" && node "$CLI" conventions "$@") >"$out" 2>&1
+  CHECK_EC=$?
+}
+
+run_check() {
+  local sb="$1" out="$2"
+  shift 2
+  (cd "$sb" && node "$CLI" conventions --check "$@") >"$out" 2>&1
+  CHECK_EC=$?
+}
+
+run_write() {
+  local sb="$1" out="$2"
+  (cd "$sb" && node "$CLI" conventions) >"$out" 2>&1
+  CHECK_EC=$?
+}
+
+show() {
+  echo "  --- command output (whole, unpiped) ------------------------------------"
+  sed 's/^/  | /' "$1"
+  echo "  ------------------------------------------------------------------------"
+}
+
+main() {
+  echo "sabotage/conventions-check.sh"
+  echo "repo   : $ROOT"
+  echo "HEAD   : $(git -C "$ROOT" rev-parse HEAD)"
+  echo "subject: sg conventions --check   (D9: generated docs are regenerate-only)"
+  echo "config : $CONFIG_REL"
+  echo "doc    : $DOC_REL"
+
+  WORK="$(mktemp -d)"
+  trap 'rm -rf "$WORK"' EXIT
+
+  # ---------------------------------------------------------------- PREFLIGHT
+  banner "P1  the arms will run against COMMITTED bytes"
+  echo "  subject of this control: the working tree status of src/, tests/,"
+  echo "  $CONFIG_REL and the generated doc. .pre-commit-config.yaml is"
+  echo "  deliberately OUT of scope: it is a /nix/store symlink that this machine"
+  echo "  rewrites on every direnv load and that is never committed."
+  local dirty
+  dirty="$(git -C "$ROOT" status --porcelain -- src tests "$CONFIG_REL" "$DOC_REL")"
+  if [ -z "$dirty" ]; then
+    ok "P1 subject paths are clean; HEAD == what the arms will read"
+  else
+    echo "  uncommitted changes in the subject paths:"
+    printf '%s\n' "$dirty" | while IFS= read -r line; do echo "  | $line"; done
+    bad "P1 subject paths are dirty; arms would not be reading committed bytes"
+  fi
+
+  banner "P2  rebuild dist/ from the committed source"
+  local buildlog="$WORK/build.log"
+  (cd "$ROOT" && pls build) >"$buildlog" 2>&1
+  local build_ec=$?
+  show "$buildlog"
+  if [ "$build_ec" -eq 0 ] && [ -f "$CLI" ]; then
+    ok "P2 build exited 0 and produced $CLI"
+  else
+    bad "P2 build exited $build_ec (dist present: $([ -f "$CLI" ] && echo yes || echo no))"
+  fi
+
+  banner "P3  the rebuilt dist/ actually contains the new code"
+  echo "  subject: the FILES tsc emitted under dist/, named individually."
+  echo "  tsc does NOT bundle -- dist/semantic-generator.js is a small require"
+  echo "  shim -- so a structural grep over the entry file alone examines almost"
+  echo "  nothing and would pass unconditionally. These are the emitted modules"
+  echo "  this feature consists of."
+  local missing=0 f
+  for f in \
+    dist/controllers/conventions-controller.js \
+    dist/classLibrary/release/conventions-checker.js \
+    dist/classLibrary/lineDiff.js; do
+    if [ -f "$ROOT/$f" ]; then
+      echo "  present: $f"
+    else
+      echo "  MISSING: $f"
+      missing=$((missing + 1))
+    fi
+  done
+  if [ "$missing" -eq 0 ]; then
+    ok "P3 all 3 expected emitted modules exist under dist/"
+  else
+    bad "P3 $missing of 3 expected emitted modules are missing from dist/"
+  fi
+  local hits
+  hits="$(grep -rlF "ConventionsChecker" "$ROOT/dist" | wc -l | tr -d ' ')"
+  echo "  files mentioning 'ConventionsChecker' (population: every file under dist/): $hits"
+
+  banner "P4  --check and --config are on the SUBCOMMAND'S OWN parser"
+  echo "  subject: the help commander itself emits for 'conventions', not the"
+  echo "  program-level help. A flag silently swallowed by an outer parser exits"
+  echo "  0 and checks nothing -- the way a subcommand --version is shadowed by"
+  echo "  the program-level -V, --version."
+  local helpout="$WORK/help.out"
+  (cd "$ROOT" && node "$CLI" conventions --help) >"$helpout" 2>&1
+  local help_ec=$?
+  show "$helpout"
+  if [ "$help_ec" -eq 0 ]; then
+    ok "P4 'conventions --help' exits 0"
+  else
+    bad "P4 'conventions --help' exited $help_ec"
+  fi
+  if grep -Fq -- "--check" "$helpout"; then
+    ok "P4 commander lists --check on the conventions subcommand"
+  else
+    bad "P4 commander does NOT list --check on the conventions subcommand"
+  fi
+  if grep -Fq -- "--config" "$helpout"; then
+    ok "P4 commander lists --config on the conventions subcommand"
+  else
+    bad "P4 commander does NOT list --config on the conventions subcommand"
+  fi
+
+  # --------------------------------------------------------------------- A1
+  banner "A1  GREEN ARM  -- committed doc vs committed config"
+  local sb out doc cfg
+  sb="$(new_sandbox a1)"
+  doc="$sb/$DOC_REL"
+  out="$WORK/a1.out"
+  echo "  doc sha256: $(sha "$doc")"
+  run_check "$sb" "$out"
+  show "$out"
+  echo "  exit code : $CHECK_EC"
+  if [ "$CHECK_EC" -eq 0 ]; then
+    ok "A1 committed bytes pass the check (exit 0)"
+  else
+    bad "A1 committed bytes FAIL the check (exit $CHECK_EC) -- the repo is in violation"
+  fi
+
+  # --------------------------------------------------------------------- A2
+  banner "A2  RED ARM  -- hand-edit the doc BODY (the real historical drift)"
+  echo "  subject: the 'fix' scope table row inside the generated doc."
+  echo "  The edit reintroduces the exact drift a076d18 left in this repo for two"
+  echo "  years: config says 'old-nix derivations', doc said 'nix derivations'."
+  sb="$(new_sandbox a2)"
+  doc="$sb/$DOC_REL"
+  out="$WORK/a2.out"
+  local needle="Fixes in old-nix derivations in the repository"
+  local replacement="Fixes in nix derivations in the repository"
+  local sha_before sha_after
+  sha_before="$(sha "$doc")"
+
+  if grep -Fq "$needle" "$doc"; then
+    ok "A2 precondition: the needle is present, so the edit cannot no-op"
+  else
+    bad "A2 precondition FAILED: needle absent; any verdict below is meaningless"
+  fi
+
+  # Neither string contains a sed metacharacter or a '/', so this substitution
+  # is literal. It is still only trusted because the sha comparison below
+  # proves it landed.
+  sed -i "s/old-nix derivations in the repository/nix derivations in the repository/" "$doc"
+  sha_after="$(sha "$doc")"
+  echo "  doc sha256 before: $sha_before"
+  echo "  doc sha256 after : $sha_after"
+  if [ "$sha_before" != "$sha_after" ]; then
+    ok "A2 MUTATION ASSERTED: the bytes on disk actually changed"
+  else
+    bad "A2 MUTATION DID NOT LAND: bytes unchanged; the arm proves nothing"
+  fi
+
+  run_check "$sb" "$out"
+  show "$out"
+  echo "  exit code : $CHECK_EC"
+  if [ "$CHECK_EC" -ne 0 ]; then
+    ok "A2 hand-edited doc is REJECTED (exit $CHECK_EC)"
+  else
+    bad "A2 hand-edited doc was ACCEPTED (exit 0) -- the check is inert"
+  fi
+  if grep -Fq "$replacement" "$out" && grep -Fq "$needle" "$out"; then
+    ok "A2 the diff names both sides of the edit"
+  else
+    bad "A2 the diff does not name both sides of the edit"
+  fi
+  if grep -Fq "regenerate-only" "$out" && grep -Fq "sg conventions" "$out"; then
+    ok "A2 the failure states the rule and a runnable remedy"
+  else
+    bad "A2 the failure does not state the rule and remedy"
+  fi
+
+  # --------------------------------------------------------------------- A3
+  banner "A3  RED ARM  -- one whitespace byte appended to the doc"
+  echo "  subject: the final byte of the generated doc. This separates a"
+  echo "  byte-exact comparison from a trimmed/normalised one."
+  sb="$(new_sandbox a3)"
+  doc="$sb/$DOC_REL"
+  out="$WORK/a3.out"
+  local size_before size_after
+  size_before="$(size "$doc")"
+  sha_before="$(sha "$doc")"
+  printf '\n' >>"$doc"
+  size_after="$(size "$doc")"
+  sha_after="$(sha "$doc")"
+  echo "  doc bytes before: $size_before   after: $size_after"
+  if [ "$size_after" -eq $((size_before + 1)) ] && [ "$sha_before" != "$sha_after" ]; then
+    ok "A3 MUTATION ASSERTED: exactly one byte longer, sha changed"
+  else
+    bad "A3 MUTATION DID NOT LAND as specified (before=$size_before after=$size_after)"
+  fi
+  run_check "$sb" "$out"
+  show "$out"
+  echo "  exit code : $CHECK_EC"
+  if [ "$CHECK_EC" -ne 0 ]; then
+    ok "A3 a whitespace-only hand-edit is REJECTED (exit $CHECK_EC)"
+  else
+    bad "A3 a whitespace-only hand-edit was ACCEPTED (exit 0)"
+  fi
+
+  # --------------------------------------------------------------------- A4
+  banner "A4  RED ARM  -- the doc is missing entirely"
+  echo "  subject: the existence of the generated doc."
+  sb="$(new_sandbox a4)"
+  doc="$sb/$DOC_REL"
+  out="$WORK/a4.out"
+  rm -f "$doc"
+  if [ ! -e "$doc" ]; then
+    ok "A4 MUTATION ASSERTED: the doc is gone from the sandbox"
+  else
+    bad "A4 MUTATION DID NOT LAND: the doc still exists"
+  fi
+  run_check "$sb" "$out"
+  show "$out"
+  echo "  exit code : $CHECK_EC"
+  if [ "$CHECK_EC" -ne 0 ]; then
+    ok "A4 a missing doc is REJECTED (exit $CHECK_EC)"
+  else
+    bad "A4 a missing doc was ACCEPTED (exit 0)"
+  fi
+
+  # --------------------------------------------------------------------- A5
+  banner "A5  RED ARM  -- drift on the CONFIG side, doc untouched"
+  echo "  subject: $CONFIG_REL. The doc keeps its committed bytes; the config"
+  echo "  gains a scope. This is the direction real drift took in a076d18, and it"
+  echo "  proves the check regenerates from the config rather than comparing the"
+  echo "  doc to a stored copy of itself."
+  sb="$(new_sandbox a5)"
+  doc="$sb/$DOC_REL"
+  cfg="$sb/$CONFIG_REL"
+  out="$WORK/a5.out"
+  local doc_sha_before cfg_sha_before cfg_sha_after doc_sha_after
+  doc_sha_before="$(sha "$doc")"
+  cfg_sha_before="$(sha "$cfg")"
+
+  local anchors
+  anchors="$(grep -c '^      config:$' "$cfg")"
+  echo "  anchor '^      config:\$' occurrences in the config: $anchors"
+  if [ "$anchors" -eq 1 ]; then
+    ok "A5 precondition: exactly one anchor line, so the injection is unambiguous"
+  else
+    bad "A5 precondition FAILED: $anchors anchor lines; the injection is ambiguous"
+  fi
+  sed -i 's/^      config:$/      sabotage-scope:\n        desc: injected by the sabotage harness\n        release: false\n      config:/' "$cfg"
+
+  cfg_sha_after="$(sha "$cfg")"
+  doc_sha_after="$(sha "$doc")"
+  echo "  config sha256 before: $cfg_sha_before"
+  echo "  config sha256 after : $cfg_sha_after"
+  echo "  doc    sha256 before: $doc_sha_before"
+  echo "  doc    sha256 after : $doc_sha_after"
+  if [ "$cfg_sha_before" != "$cfg_sha_after" ]; then
+    ok "A5 MUTATION ASSERTED: the config bytes changed"
+  else
+    bad "A5 MUTATION DID NOT LAND: the config is unchanged"
+  fi
+  if [ "$doc_sha_before" = "$doc_sha_after" ]; then
+    ok "A5 CONTROL: the doc was NOT touched, so only the config moved"
+  else
+    bad "A5 CONTROL FAILED: the doc changed too; the arm is not isolated"
+  fi
+
+  run_check "$sb" "$out"
+  show "$out"
+  echo "  exit code : $CHECK_EC"
+  if [ "$CHECK_EC" -ne 0 ]; then
+    ok "A5 a doc left stale by a config change is REJECTED (exit $CHECK_EC)"
+  else
+    bad "A5 a doc left stale by a config change was ACCEPTED (exit 0)"
+  fi
+  if grep -Fq "sabotage-scope" "$out"; then
+    ok "A5 the diff names the scope that was added to the config"
+  else
+    bad "A5 the diff does not name the newly added scope"
+  fi
+
+  # --------------------------------------------------------------------- A6
+  banner "A6  NON-MUTATION CONTROL  -- rewrite the doc with IDENTICAL bytes"
+  echo "  subject: the discrimination of the check itself. If A2/A3/A4 went red"
+  echo "  merely because the file had been written to, this arm would go red too"
+  echo "  and the red arms above would carry no information."
+  sb="$(new_sandbox a6)"
+  doc="$sb/$DOC_REL"
+  out="$WORK/a6.out"
+  sha_before="$(sha "$doc")"
+  cat "$doc" >"$doc.tmp" && mv "$doc.tmp" "$doc"
+  touch "$doc"
+  sha_after="$(sha "$doc")"
+  echo "  doc sha256 before: $sha_before"
+  echo "  doc sha256 after : $sha_after"
+  if [ "$sha_before" = "$sha_after" ]; then
+    ok "A6 NON-MUTATION ASSERTED: the file was rewritten, bytes identical"
+  else
+    bad "A6 the no-op rewrite changed the bytes; the control is invalid"
+  fi
+  run_check "$sb" "$out"
+  show "$out"
+  echo "  exit code : $CHECK_EC"
+  if [ "$CHECK_EC" -eq 0 ]; then
+    ok "A6 an identical rewrite is ACCEPTED (exit 0) -- the check reads content"
+  else
+    bad "A6 an identical rewrite was REJECTED (exit $CHECK_EC) -- the check is not content-based"
+  fi
+
+  # --------------------------------------------------------------------- A7
+  banner "A7  READ-ONLY CONTROL  -- --check must not repair the file"
+  echo "  subject: the doc's bytes across a failing --check run. A check that"
+  echo "  silently rewrites the file would go green on the second CI run and"
+  echo "  hide the violation instead of reporting it."
+  sb="$(new_sandbox a7)"
+  doc="$sb/$DOC_REL"
+  out="$WORK/a7.out"
+  printf '\nhand written paragraph\n' >>"$doc"
+  sha_before="$(sha "$doc")"
+  run_check "$sb" "$out"
+  sha_after="$(sha "$doc")"
+  show "$out"
+  echo "  exit code : $CHECK_EC"
+  echo "  doc sha256 before check: $sha_before"
+  echo "  doc sha256 after  check: $sha_after"
+  if [ "$CHECK_EC" -ne 0 ]; then
+    ok "A7 the tampered doc is REJECTED (exit $CHECK_EC)"
+  else
+    bad "A7 the tampered doc was ACCEPTED (exit 0)"
+  fi
+  if [ "$sha_before" = "$sha_after" ]; then
+    ok "A7 --check left the file byte-identical"
+  else
+    bad "A7 --check MODIFIED the file; it is not read-only"
+  fi
+
+  # --------------------------------------------------------------------- A8
+  banner "A8  UNREADABLE-CONFIG CONTROL  -- must not pass when it cannot read"
+  echo "  subject: the -c flag pointed at a path that does not exist. A checker"
+  echo "  that exits 0 when its input is missing reports 'safe' for the wrong"
+  echo "  reason -- the single most common way a guard turns inert."
+  sb="$(new_sandbox a8)"
+  out="$WORK/a8.out"
+  if [ ! -e "$sb/definitely-not-here.yaml" ]; then
+    ok "A8 precondition: the config path really is absent"
+  else
+    bad "A8 precondition FAILED: the path exists"
+  fi
+  run_check "$sb" "$out" -c definitely-not-here.yaml
+  show "$out"
+  echo "  exit code : $CHECK_EC"
+  if [ "$CHECK_EC" -ne 0 ]; then
+    ok "A8 an unreadable config is REJECTED (exit $CHECK_EC)"
+  else
+    bad "A8 an unreadable config was ACCEPTED (exit 0) -- inert guard"
+  fi
+
+  # --------------------------------------------------------------------- A9
+  banner "A9  REMEDY ARM  -- 'sg conventions' repairs what --check rejects"
+  echo "  subject: the doc's bytes before and after the remedy command. D9's"
+  echo "  remedy has to be a runnable command; if it were not, the only way to"
+  echo "  clear the check would be the hand-edit D9 forbids."
+  sb="$(new_sandbox a9)"
+  doc="$sb/$DOC_REL"
+  out="$WORK/a9.out"
+  local sha_committed
+  sha_committed="$(sha "$doc")"
+  printf '\nhand written paragraph\n' >>"$doc"
+  sha_before="$(sha "$doc")"
+  if [ "$sha_committed" != "$sha_before" ]; then
+    ok "A9 MUTATION ASSERTED: the doc no longer matches the committed bytes"
+  else
+    bad "A9 MUTATION DID NOT LAND"
+  fi
+
+  run_check "$sb" "$WORK/a9-pre.out"
+  local pre_ec=$CHECK_EC
+  echo "  --check before remedy exit: $pre_ec"
+
+  run_write "$sb" "$out"
+  show "$out"
+  echo "  write exit code : $CHECK_EC"
+  sha_after="$(sha "$doc")"
+  echo "  doc sha256 committed : $sha_committed"
+  echo "  doc sha256 tampered  : $sha_before"
+  echo "  doc sha256 after 'sg conventions' : $sha_after"
+
+  run_check "$sb" "$WORK/a9-post.out"
+  local post_ec=$CHECK_EC
+  show "$WORK/a9-post.out"
+  echo "  --check after remedy exit: $post_ec"
+
+  if [ "$pre_ec" -ne 0 ]; then
+    ok "A9 the tampered doc was RED before the remedy"
+  else
+    bad "A9 the tampered doc was already green; the arm proves nothing"
+  fi
+  if [ "$sha_after" = "$sha_committed" ]; then
+    ok "A9 'sg conventions' restored the exact committed bytes"
+  else
+    bad "A9 'sg conventions' did not restore the committed bytes"
+  fi
+  if [ "$post_ec" -eq 0 ]; then
+    ok "A9 --check is GREEN after the remedy"
+  else
+    bad "A9 --check is still red after the remedy (exit $post_ec)"
+  fi
+
+  # ==========================================================================
+  # B-SERIES -- the -c/--config half.
+  #
+  # This is a DIFFERENT question from the A-series and is stated separately on
+  # purpose. A-series asks "does the check refuse a stale hand-edited doc?"
+  # (D9). B-series asks "does the command read the config I named?" (D6 /
+  # WF3's rename). They are adjacent, not the same, and an answer to one is
+  # not an answer to the other.
+  # ==========================================================================
+  local committed_doc_sha
+  committed_doc_sha="$(git -C "$ROOT" show "HEAD:$DOC_REL" | sha256sum | cut -d' ' -f1)"
+
+  banner "B1  WRITE ARM  -- renamed config (the WF3 end state), doc absent"
+  echo "  subject: docs/developer/03-Commit Conventions.md as an OUTPUT. The"
+  echo "  sandbox holds release.yaml and no atomi_release.yaml at all."
+  echo "  The exit code is not the finding here; the file appearing is."
+  sb="$(new_sandbox_named b1 release.yaml no-doc)"
+  doc="$sb/$DOC_REL"
+  out="$WORK/b1.out"
+  if [ ! -e "$sb/$CONFIG_REL" ]; then
+    ok "B1 precondition: the old config name is absent from the sandbox"
+  else
+    bad "B1 precondition FAILED: $CONFIG_REL exists; the arm cannot isolate the flag"
+  fi
+  if [ ! -e "$doc" ]; then
+    ok "B1 precondition: the doc does not exist before the run"
+  else
+    bad "B1 precondition FAILED: the doc already exists"
+  fi
+  run_write_args "$sb" "$out" -c release.yaml
+  show "$out"
+  echo "  exit code : $CHECK_EC"
+  if [ -f "$doc" ]; then
+    sha_after="$(sha "$doc")"
+    echo "  doc sha256 written   : $sha_after"
+    echo "  doc sha256 committed : $committed_doc_sha"
+    ok "B1 MUTATION ASSERTED: the doc did not exist before and exists now"
+    if [ "$sha_after" = "$committed_doc_sha" ]; then
+      ok "B1 the written bytes are identical to the committed doc"
+    else
+      bad "B1 the written bytes differ from the committed doc"
+    fi
+  else
+    bad "B1 MUTATION DID NOT LAND: no file was written (exit was $CHECK_EC)"
+  fi
+  if [ "$CHECK_EC" -eq 0 ]; then
+    ok "B1 'conventions -c release.yaml' exits 0 on the WF3 end state"
+  else
+    bad "B1 'conventions -c release.yaml' exited $CHECK_EC on the WF3 end state"
+  fi
+
+  banner "B2  WRITE ARM, NEGATIVE  -- -c points at a config that is not there"
+  echo "  subject: the -c path on the WRITE path specifically. Without this the"
+  echo "  B1 exit 0 cannot be told apart from a command that ignores -c."
+  sb="$(new_sandbox_named b2 release.yaml no-doc)"
+  doc="$sb/$DOC_REL"
+  out="$WORK/b2.out"
+  if [ ! -e "$sb/nope.yaml" ]; then
+    ok "B2 precondition: nope.yaml really is absent"
+  else
+    bad "B2 precondition FAILED: nope.yaml exists"
+  fi
+  run_write_args "$sb" "$out" -c nope.yaml
+  show "$out"
+  echo "  exit code : $CHECK_EC"
+  if [ "$CHECK_EC" -ne 0 ]; then
+    ok "B2 a missing config is REJECTED on the write path (exit $CHECK_EC)"
+  else
+    bad "B2 a missing config was ACCEPTED on the write path (exit 0)"
+  fi
+  if grep -Fq "nope.yaml" "$out"; then
+    ok "B2 the failure names the config path it could not read"
+  else
+    bad "B2 the failure does not name the config path"
+  fi
+  if [ ! -e "$doc" ]; then
+    ok "B2 NON-MUTATION ASSERTED: nothing was written on the failing path"
+  else
+    bad "B2 a doc was written despite the config being unreadable"
+  fi
+
+  banner "B3  WRITE DISCRIMINATOR  -- BOTH config names present, -c must decide"
+  echo "  subject: which of two present configs the write path actually read."
+  echo "  B1 and B2 together still cannot separate 'read release.yaml' from"
+  echo "  'ignored -c and found atomi_release.yaml anyway', because in a sandbox"
+  echo "  holding only one config both behaviours look identical. Here both"
+  echo "  names exist; only release.yaml carries the marker."
+  sb="$(new_sandbox_named b3 release.yaml no-doc)"
+  doc="$sb/$DOC_REL"
+  cfg="$sb/release.yaml"
+  out="$WORK/b3.out"
+  git -C "$ROOT" show "HEAD:$CONFIG_REL" >"$sb/$CONFIG_REL"
+  local marker="MARKER-ONLY-IN-RELEASE-YAML"
+  sed -i "s/desc: Fixes in configuration/desc: $marker/" "$cfg"
+
+  if grep -Fq "$marker" "$cfg"; then
+    ok "B3 MUTATION ASSERTED: the marker is in release.yaml"
+  else
+    bad "B3 MUTATION DID NOT LAND: the marker is not in release.yaml"
+  fi
+  if grep -Fq "$marker" "$sb/$CONFIG_REL"; then
+    bad "B3 CONTROL FAILED: the marker leaked into $CONFIG_REL; it cannot discriminate"
+  else
+    ok "B3 CONTROL: the marker is absent from $CONFIG_REL, so it discriminates"
+  fi
+  if [ -f "$sb/$CONFIG_REL" ] && [ -f "$cfg" ]; then
+    ok "B3 precondition: BOTH config names are present in the sandbox"
+  else
+    bad "B3 precondition FAILED: both config names are not present"
+  fi
+
+  run_write_args "$sb" "$out" -c release.yaml
+  show "$out"
+  echo "  exit code : $CHECK_EC"
+  if [ "$CHECK_EC" -eq 0 ] && [ -f "$doc" ]; then
+    ok "B3 the write succeeded and produced a file"
+  else
+    bad "B3 the write did not produce a file (exit $CHECK_EC)"
+  fi
+  if [ -f "$doc" ] && grep -Fq "$marker" "$doc"; then
+    ok "B3 the written doc carries the marker -- -c release.yaml WAS read"
+  else
+    bad "B3 the written doc has no marker -- -c was ignored and $CONFIG_REL was read"
+  fi
+
+  banner "B4  CHECK DISCRIMINATOR  -- --check must honour -c too"
+  echo "  subject: which of two present configs --check regenerated from. The"
+  echo "  doc on disk is the committed one, which matches $CONFIG_REL exactly."
+  echo "  If --check ignored -c it would read $CONFIG_REL and go GREEN. Honouring"
+  echo "  -c means regenerating from the marked release.yaml and going RED."
+  sb="$(new_sandbox_named b4 release.yaml with-doc)"
+  doc="$sb/$DOC_REL"
+  cfg="$sb/release.yaml"
+  out="$WORK/b4.out"
+  git -C "$ROOT" show "HEAD:$CONFIG_REL" >"$sb/$CONFIG_REL"
+  sed -i "s/desc: Fixes in configuration/desc: $marker/" "$cfg"
+  sha_before="$(sha "$doc")"
+  if [ "$sha_before" = "$committed_doc_sha" ]; then
+    ok "B4 precondition: the doc on disk is byte-identical to the committed doc"
+  else
+    bad "B4 precondition FAILED: the doc is not the committed one"
+  fi
+
+  run_check "$sb" "$WORK/b4-control.out" -c "$CONFIG_REL"
+  echo "  CONTROL, --check -c $CONFIG_REL (the UNMARKED config) exit: $CHECK_EC"
+  if [ "$CHECK_EC" -eq 0 ]; then
+    ok "B4 CONTROL: against the unmarked config the same doc is GREEN"
+  else
+    bad "B4 CONTROL FAILED: the doc is red even against the unmarked config; B4 proves nothing"
+  fi
+
+  run_check "$sb" "$out" -c release.yaml
+  show "$out"
+  echo "  exit code : $CHECK_EC"
+  if [ "$CHECK_EC" -ne 0 ]; then
+    ok "B4 --check -c release.yaml is RED -- it regenerated from the named config"
+  else
+    bad "B4 --check -c release.yaml is GREEN -- it ignored -c and read $CONFIG_REL"
+  fi
+  if grep -Fq "$marker" "$out"; then
+    ok "B4 the diff names the marker that exists only in release.yaml"
+  else
+    bad "B4 the diff does not name the marker"
+  fi
+  sha_after="$(sha "$doc")"
+  if [ "$sha_before" = "$sha_after" ]; then
+    ok "B4 --check left the doc byte-identical, as on the A-series"
+  else
+    bad "B4 --check MODIFIED the doc"
+  fi
+
+  # ------------------------------------------------------------------ SUMMARY
+  banner "SUMMARY"
+  echo "  population: 4 preflight controls (P1-P4), 9 D9 arms (A1-A9) and 4"
+  echo "  config-flag arms (B1-B4), run against the committed bytes of HEAD with"
+  echo "  a dist/ rebuilt from that same source."
+  echo "  assertions executed: $((pass + fail))"
+  echo "  passed: $pass"
+  echo "  failed: $fail"
+  echo
+  if [ "$fail" -eq 0 ]; then
+    echo "  RESULT: every arm behaved as specified."
+    echo
+    echo "  D9 half (--check refuses a stale generated doc). Shown ABLE TO GO RED"
+    echo "  on four distinct sabotages -- doc body, doc trailing byte, missing"
+    echo "  doc, config-side drift -- each with the sabotage itself asserted to"
+    echo "  have landed, and ABLE TO STAY GREEN on a byte-identical rewrite."
+    echo "  STRONG."
+    echo
+    echo "  D6/WF3 half (-c reads a renamed config). Shown to WRITE on the"
+    echo "  renamed end state with the written bytes asserted, to go RED on a"
+    echo "  missing config without writing anything, and -- with BOTH config"
+    echo "  names present and only the named one marked -- to follow the marker"
+    echo "  on the write path and on the check path. That last pair is what"
+    echo "  separates 'read my config' from 'ignored my flag and found"
+    echo "  atomi_release.yaml anyway'. STRONG."
+    return 0
+  fi
+  echo "  RESULT: $fail assertion(s) failed. Read the arms above before"
+  echo "  concluding anything about the check."
+  return 1
+}
+
+mkdir -p "$(dirname "$OUT_FILE")"
+main 2>&1 | tee "$OUT_FILE"
+exit "${PIPESTATUS[0]}"

--- a/src/classLibrary/lineDiff.ts
+++ b/src/classLibrary/lineDiff.ts
@@ -1,0 +1,217 @@
+interface UnifiedDiffOptions {
+  /**
+   * Number of unchanged lines rendered around each change. Default 3.
+   */
+  context?: number;
+  /**
+   * Label rendered on the `---` header line, describing the `-` side.
+   */
+  expectedLabel?: string;
+  /**
+   * Label rendered on the `+++` header line, describing the `+` side.
+   */
+  actualLabel?: string;
+  /**
+   * Safety valve for the O(n*m) LCS table. When the table would exceed this
+   * many cells, a coarse summary is rendered instead of a full diff.
+   */
+  maxCells?: number;
+}
+
+const DefaultContext = 3;
+const DefaultMaxCells = 4000000;
+
+type OpKind = "equal" | "del" | "add";
+
+interface Op {
+  kind: OpKind;
+  line: string;
+}
+
+interface Range {
+  start: number;
+  end: number;
+}
+
+interface SplitFile {
+  lines: string[];
+  trailingNewline: boolean;
+}
+
+/**
+ * Splits a file body into its lines, recording separately whether the body
+ * ended with a newline. `lines` + `trailingNewline` losslessly reconstruct the
+ * original string, so a difference that lives purely in the trailing newline is
+ * never silently swallowed.
+ */
+function SplitLines(s: string): SplitFile {
+  if (s === "") return { lines: [], trailingNewline: false };
+  const parts = s.split("\n");
+  if (parts[parts.length - 1] === "") {
+    parts.pop();
+    return { lines: parts, trailingNewline: true };
+  }
+  return { lines: parts, trailingNewline: false };
+}
+
+function FirstDifferingLine(a: string[], b: string[]): number {
+  const shorter = Math.min(a.length, b.length);
+  for (let i = 0; i < shorter; i++) {
+    if (a[i] !== b[i]) return i + 1;
+  }
+  return shorter + 1;
+}
+
+function ComputeOps(a: string[], b: string[]): Op[] {
+  const n = a.length;
+  const m = b.length;
+  const width = m + 1;
+  const dp = new Uint32Array((n + 1) * width);
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      dp[i * width + j] =
+        a[i] === b[j]
+          ? dp[(i + 1) * width + (j + 1)] + 1
+          : Math.max(dp[(i + 1) * width + j], dp[i * width + (j + 1)]);
+    }
+  }
+
+  const ops: Op[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < n && j < m) {
+    if (a[i] === b[j]) {
+      ops.push({ kind: "equal", line: a[i] });
+      i++;
+      j++;
+    } else if (dp[(i + 1) * width + j] >= dp[i * width + (j + 1)]) {
+      ops.push({ kind: "del", line: a[i] });
+      i++;
+    } else {
+      ops.push({ kind: "add", line: b[j] });
+      j++;
+    }
+  }
+  while (i < n) {
+    ops.push({ kind: "del", line: a[i] });
+    i++;
+  }
+  while (j < m) {
+    ops.push({ kind: "add", line: b[j] });
+    j++;
+  }
+  return ops;
+}
+
+function HunkRanges(ops: Op[], context: number): Range[] {
+  const ranges: Range[] = [];
+  for (let k = 0; k < ops.length; k++) {
+    if (ops[k].kind === "equal") continue;
+    let end = k;
+    while (end + 1 < ops.length && ops[end + 1].kind !== "equal") end++;
+    ranges.push({
+      start: Math.max(0, k - context),
+      end: Math.min(ops.length - 1, end + context),
+    });
+    k = end;
+  }
+
+  const merged: Range[] = [];
+  for (const r of ranges) {
+    const last = merged.length > 0 ? merged[merged.length - 1] : null;
+    if (last != null && r.start <= last.end + 1) {
+      last.end = Math.max(last.end, r.end);
+    } else {
+      merged.push({ start: r.start, end: r.end });
+    }
+  }
+  return merged;
+}
+
+function RenderHunks(ops: Op[], context: number): string[] {
+  const expectedLineAt: number[] = new Array(ops.length);
+  const actualLineAt: number[] = new Array(ops.length);
+  let expectedLine = 1;
+  let actualLine = 1;
+  for (let k = 0; k < ops.length; k++) {
+    expectedLineAt[k] = expectedLine;
+    actualLineAt[k] = actualLine;
+    if (ops[k].kind !== "add") expectedLine++;
+    if (ops[k].kind !== "del") actualLine++;
+  }
+
+  const out: string[] = [];
+  for (const range of HunkRanges(ops, context)) {
+    let expectedCount = 0;
+    let actualCount = 0;
+    const body: string[] = [];
+    for (let k = range.start; k <= range.end; k++) {
+      const op = ops[k];
+      if (op.kind !== "add") expectedCount++;
+      if (op.kind !== "del") actualCount++;
+      const prefix = op.kind === "del" ? "-" : op.kind === "add" ? "+" : " ";
+      body.push(`${prefix}${op.line}`);
+    }
+    const expectedStart = expectedCount === 0 ? 0 : expectedLineAt[range.start];
+    const actualStart = actualCount === 0 ? 0 : actualLineAt[range.start];
+    out.push(
+      `@@ -${expectedStart},${expectedCount} +${actualStart},${actualCount} @@`,
+    );
+    for (const line of body) out.push(line);
+  }
+  return out;
+}
+
+/**
+ * Renders a unified diff of two file bodies. Returns the empty string when the
+ * two bodies are byte-identical, so the return value doubles as a "they differ"
+ * signal.
+ *
+ * `-` lines come from `expected`, `+` lines come from `actual`.
+ */
+function UnifiedDiff(
+  expected: string,
+  actual: string,
+  options: UnifiedDiffOptions = {},
+): string {
+  if (expected === actual) return "";
+
+  const context = options.context ?? DefaultContext;
+  const maxCells = options.maxCells ?? DefaultMaxCells;
+  const expectedLabel = options.expectedLabel ?? "expected";
+  const actualLabel = options.actualLabel ?? "actual";
+
+  const e = SplitLines(expected);
+  const a = SplitLines(actual);
+  const header = [`--- ${expectedLabel}`, `+++ ${actualLabel}`];
+
+  if ((e.lines.length + 1) * (a.lines.length + 1) > maxCells) {
+    return [
+      ...header,
+      `(too large to diff: ${e.lines.length} expected lines vs ${a.lines.length} actual lines; first difference at line ${FirstDifferingLine(e.lines, a.lines)})`,
+    ].join("\n");
+  }
+
+  const body = RenderHunks(ComputeOps(e.lines, a.lines), context);
+
+  const notes: string[] = [];
+  if (e.trailingNewline !== a.trailingNewline) {
+    notes.push(
+      e.trailingNewline
+        ? `\\ ${actualLabel} has no newline at end of file`
+        : `\\ ${expectedLabel} has no newline at end of file`,
+    );
+  }
+
+  if (body.length === 0) {
+    body.push(
+      notes.length > 0
+        ? "(lines are identical; only the trailing newline differs)"
+        : "(bodies differ)",
+    );
+  }
+
+  return [...header, ...body, ...notes].join("\n");
+}
+
+export { UnifiedDiff, UnifiedDiffOptions, SplitLines };

--- a/src/classLibrary/release/config-reader.ts
+++ b/src/classLibrary/release/config-reader.ts
@@ -8,9 +8,17 @@ import {
   ReleaseConfigurationValid,
 } from "./configuration";
 
+/**
+ * The one and only default name of the release configuration file. Anything
+ * that needs to name the config — help text, error messages — must read it from
+ * here rather than spelling it out again, so the name lives in exactly one
+ * place.
+ */
+const DefaultReleaseConfigPath = "atomi_release.yaml";
+
 class ConfigReader {
   Read(c: Option<string>): PromiseResult<ReleaseConfiguration, string[]> {
-    return ReadFile(c.unwrapOr("atomi_release.yaml"))
+    return ReadFile(c.unwrapOr(DefaultReleaseConfigPath))
       .andThen((c) => ContentToString(c))
       .mapErr((x) => [x])
       .map((s) => yaml.parse(s))
@@ -18,4 +26,4 @@ class ConfigReader {
   }
 }
 
-export { ConfigReader };
+export { ConfigReader, DefaultReleaseConfigPath };

--- a/src/classLibrary/release/conventions-checker.ts
+++ b/src/classLibrary/release/conventions-checker.ts
@@ -1,0 +1,126 @@
+import * as path from "path";
+import { Err, Ok, Result } from "@hqoss/monads";
+import { CommitConventionDocumentParser } from "./documentParser";
+import { ReleaseConfiguration } from "./configuration";
+import { IWritable, Writer } from "../engine/writer";
+import { ReadBinary } from "../engine/basicFileFactory";
+import { Content, VFile } from "../engine/vfs";
+import { PromiseResult } from "../resultUtil";
+import { UnifiedDiff } from "../lineDiff";
+
+/**
+ * Guards the "generated docs are regenerate-only" rule for the commit
+ * convention document.
+ *
+ * `Write` produces the document exactly as `ReleaseExecutor.Release` does, so
+ * the remedy for a failing check is a real command rather than an instruction
+ * to hand-edit — which is the thing the rule forbids.
+ *
+ * `Check` never writes. It regenerates the document in memory and compares it
+ * byte-for-byte against the file on disk, so it is safe to run in CI and on a
+ * read-only checkout.
+ */
+class ConventionsChecker {
+  private readonly docParser: CommitConventionDocumentParser;
+  private readonly writer: Writer;
+  private readonly target: string;
+  private readonly configPath: string;
+
+  constructor(
+    docParser: CommitConventionDocumentParser,
+    writer: Writer,
+    target: string,
+    configPath: string,
+  ) {
+    this.docParser = docParser;
+    this.writer = writer;
+    this.target = target;
+    this.configPath = configPath;
+  }
+
+  /**
+   * The document as it should exist on disk. This is the same call
+   * `ReleaseExecutor.Release` makes, so the check and the release cannot drift
+   * apart.
+   */
+  Generate(rc: ReleaseConfiguration): string {
+    return this.docParser.GenerateDocument(rc);
+  }
+
+  private writable(rc: ReleaseConfiguration): IWritable {
+    const docs: VFile = {
+      content: Content.String(this.Generate(rc)),
+      meta: {
+        from: "",
+        original: rc.conventionMarkdown.path,
+      },
+    };
+    return IWritable.File(docs);
+  }
+
+  /**
+   * Regenerates the document and writes it to `conventionMarkdown.path`.
+   */
+  Write(rc: ReleaseConfiguration): PromiseResult<string, string> {
+    const target = rc.conventionMarkdown.path;
+    return new PromiseResult<string, string>(
+      this.writer.Write(this.writable(rc)).then((o) =>
+        o.match({
+          none: (): Result<string, string> =>
+            Ok(`regenerated ${target} from ${this.configPath}`),
+          some: (e: string): Result<string, string> =>
+            Err(`failed to write ${target}: ${e}`),
+        }),
+      ),
+    );
+  }
+
+  /**
+   * Compares the bytes on disk against the regenerated document. Ok when they
+   * match; Err carrying a readable unified diff when they do not.
+   */
+  Check(rc: ReleaseConfiguration): PromiseResult<string, string> {
+    const target = rc.conventionMarkdown.path;
+    const expected = this.Generate(rc);
+    const expectedBuffer = Buffer.from(expected, "utf8");
+
+    return ReadBinary(path.resolve(this.target, target))
+      .mapErr((e) => `cannot read ${target}: ${e}\n\n${this.remedy(target)}`)
+      .andThen((actualBuffer): Result<string, string> => {
+        if (expectedBuffer.equals(actualBuffer)) {
+          return Ok(`${target} is up to date with ${this.configPath}`);
+        }
+        return Err(this.report(target, expected, actualBuffer));
+      });
+  }
+
+  private remedy(target: string): string {
+    return [
+      `${target} is a GENERATED file: it is produced from the "conventionMarkdown"`,
+      `section of ${this.configPath} and is regenerate-only. Hand-edits are not allowed.`,
+      ``,
+      `To fix: change ${this.configPath}, run "sg conventions", and commit the result.`,
+    ].join("\n");
+  }
+
+  private report(
+    target: string,
+    expected: string,
+    actualBuffer: Buffer,
+  ): string {
+    const actual = actualBuffer.toString("utf8");
+    const diff = UnifiedDiff(expected, actual, {
+      expectedLabel: `expected: regenerated from ${this.configPath}`,
+      actualLabel: `actual:   ${target} on disk`,
+    });
+    return [
+      `${target} does not match the document generated from ${this.configPath}.`,
+      ``,
+      this.remedy(target),
+      ``,
+      diff,
+    ].join("\n");
+  }
+}
+
+export { ConventionsChecker };

--- a/src/controllers/conventions-controller.ts
+++ b/src/controllers/conventions-controller.ts
@@ -1,0 +1,72 @@
+import { Command } from "commander";
+import { Core } from "@kirinnee/core";
+import * as path from "path";
+import { Wrap } from "../classLibrary/util";
+import {
+  ConfigReader,
+  DefaultReleaseConfigPath,
+} from "../classLibrary/release/config-reader";
+import { CommitConventionDocumentParser } from "../classLibrary/release/documentParser";
+import { ConventionsChecker } from "../classLibrary/release/conventions-checker";
+import { BasicWriter } from "../classLibrary/engine/writer";
+import { VarResolver } from "../classLibrary/engine/resolver";
+import { MarkdownTable } from "../markdown-table";
+
+interface ConventionsOptions {
+  config?: string;
+  check?: boolean;
+}
+
+export function ConventionsController(core: Core, c: Command): void {
+  c.description(
+    "Generate the commit convention document from the release configuration",
+  )
+    .option(
+      "-c, --config <cfg>",
+      `path to configuration. default: ${DefaultReleaseConfigPath}`,
+    )
+    .option(
+      "--check",
+      "do not write; verify the document on disk matches the generated one and exit 1 if it does not",
+    )
+    .action(async function (opts: ConventionsOptions) {
+      let error = false;
+      try {
+        const cwd = path.resolve(".");
+        const configPath = Wrap(opts.config);
+        const vResolver = new VarResolver(core);
+        const mdt = new MarkdownTable(core);
+        const docParser = new CommitConventionDocumentParser(
+          vResolver,
+          mdt,
+          core,
+        );
+        const writer = new BasicWriter(core, cwd);
+        const reader = new ConfigReader();
+        const checker = new ConventionsChecker(
+          docParser,
+          writer,
+          cwd,
+          configPath.unwrapOr(DefaultReleaseConfigPath),
+        );
+
+        const r = await reader
+          .Read(configPath)
+          .mapErr((e) => e.join("\n"))
+          .andThenAsync((rc) =>
+            opts.check === true ? checker.Check(rc) : checker.Write(rc),
+          ).promise;
+
+        r.match({
+          err: (e) => {
+            console.warn(e);
+            error = true;
+          },
+          ok: (o) => console.log(o),
+        });
+      } catch (err) {
+        console.warn(err);
+      }
+      if (error) process.exit(1);
+    });
+}

--- a/src/semantic-generator.ts
+++ b/src/semantic-generator.ts
@@ -6,6 +6,7 @@ import * as process from "process";
 import { ReleaseController } from "./controllers/release-controller";
 import { GitlintController } from "./controllers/gitlint-controller";
 import { CommitterController } from "./controllers/committer-controller";
+import { ConventionsController } from "./controllers/conventions-controller";
 
 const core: Core = new Kore();
 core.ExtendPrimitives();
@@ -36,5 +37,8 @@ GitlintController(core, gitlint);
 
 const committer = program.command("committer");
 CommitterController(core, committer);
+
+const conventions = program.command("conventions");
+ConventionsController(core, conventions);
 
 program.parse(process.argv);

--- a/tests/lineDiff.spec.ts
+++ b/tests/lineDiff.spec.ts
@@ -1,0 +1,151 @@
+import { SplitLines, UnifiedDiff } from "../src/classLibrary/lineDiff";
+import { should } from "chai";
+
+should();
+
+describe("SplitLines", function () {
+  it("should report an empty body as zero lines without a trailing newline", function () {
+    const act = SplitLines("");
+    act.lines.length.should.equal(0);
+    act.trailingNewline.should.equal(false);
+  });
+
+  it("should separate the trailing newline from the line content", function () {
+    const act = SplitLines("a\nb\n");
+    act.lines.should.deep.equal(["a", "b"]);
+    act.trailingNewline.should.equal(true);
+  });
+
+  it("should flag a body that does not end with a newline", function () {
+    const act = SplitLines("a\nb");
+    act.lines.should.deep.equal(["a", "b"]);
+    act.trailingNewline.should.equal(false);
+  });
+
+  it("should treat a lone newline as one empty line", function () {
+    const act = SplitLines("\n");
+    act.lines.should.deep.equal([""]);
+    act.trailingNewline.should.equal(true);
+  });
+});
+
+describe("UnifiedDiff", function () {
+  it("should return an empty string for identical bodies", function () {
+    UnifiedDiff("a\nb\nc\n", "a\nb\nc\n").should.equal("");
+  });
+
+  it("should render a replaced line as a - and a + with the surrounding context", function () {
+    const expected = "one\ntwo\nthree\nfour\nfive\n";
+    const actual = "one\ntwo\nTHREE\nfour\nfive\n";
+    const act = UnifiedDiff(expected, actual);
+    act.should.equal(
+      [
+        "--- expected",
+        "+++ actual",
+        "@@ -1,5 +1,5 @@",
+        " one",
+        " two",
+        "-three",
+        "+THREE",
+        " four",
+        " five",
+      ].join("\n"),
+    );
+  });
+
+  it("should render an inserted line as a + only", function () {
+    const act = UnifiedDiff("a\nb\n", "a\ninserted\nb\n");
+    act.should.equal(
+      [
+        "--- expected",
+        "+++ actual",
+        "@@ -1,2 +1,3 @@",
+        " a",
+        "+inserted",
+        " b",
+      ].join("\n"),
+    );
+  });
+
+  it("should render a deleted line as a - only", function () {
+    const act = UnifiedDiff("a\ngone\nb\n", "a\nb\n");
+    act.should.equal(
+      [
+        "--- expected",
+        "+++ actual",
+        "@@ -1,3 +1,2 @@",
+        " a",
+        "-gone",
+        " b",
+      ].join("\n"),
+    );
+  });
+
+  it("should use the supplied labels", function () {
+    const act = UnifiedDiff("a\n", "b\n", {
+      expectedLabel: "generated",
+      actualLabel: "on disk",
+    });
+    act.should.contain("--- generated");
+    act.should.contain("+++ on disk");
+  });
+
+  it("should split distant changes into separate hunks", function () {
+    const base: string[] = [];
+    for (let i = 1; i <= 20; i++) base.push(`line ${i}`);
+    const expected = base.join("\n") + "\n";
+    const mutated = base.slice();
+    mutated[1] = "CHANGED 2";
+    mutated[17] = "CHANGED 18";
+    const actual = mutated.join("\n") + "\n";
+
+    const act = UnifiedDiff(expected, actual);
+    const hunks = act.split("\n").filter((x) => x.startsWith("@@"));
+    hunks.length.should.equal(2);
+    hunks[0].should.equal("@@ -1,5 +1,5 @@");
+    hunks[1].should.equal("@@ -15,6 +15,6 @@");
+  });
+
+  it("should merge changes that are close enough to share context", function () {
+    const base: string[] = [];
+    for (let i = 1; i <= 12; i++) base.push(`line ${i}`);
+    const mutated = base.slice();
+    mutated[3] = "CHANGED 4";
+    mutated[6] = "CHANGED 7";
+
+    const act = UnifiedDiff(base.join("\n") + "\n", mutated.join("\n") + "\n");
+    act
+      .split("\n")
+      .filter((x) => x.startsWith("@@"))
+      .length.should.equal(1);
+  });
+
+  it("should report a difference that lives only in the trailing newline", function () {
+    const act = UnifiedDiff("a\nb\n", "a\nb");
+    act.should.equal(
+      [
+        "--- expected",
+        "+++ actual",
+        "(lines are identical; only the trailing newline differs)",
+        "\\ actual has no newline at end of file",
+      ].join("\n"),
+    );
+  });
+
+  it("should note the missing trailing newline on the expected side", function () {
+    const act = UnifiedDiff("a\nb", "a\nb\n");
+    act.should.contain("\\ expected has no newline at end of file");
+  });
+
+  it("should fall back to a summary when the bodies are too large to diff", function () {
+    const a: string[] = [];
+    const b: string[] = [];
+    for (let i = 0; i < 10; i++) {
+      a.push(`a${i}`);
+      b.push(`b${i}`);
+    }
+    const act = UnifiedDiff(a.join("\n"), b.join("\n"), { maxCells: 10 });
+    act.should.contain("too large to diff");
+    act.should.contain("first difference at line 1");
+  });
+});

--- a/tests/release/conventions-checker.spec.ts
+++ b/tests/release/conventions-checker.spec.ts
@@ -1,0 +1,243 @@
+import * as fs from "fs";
+import * as path from "path";
+import rimraf from "rimraf";
+import { Kore } from "@kirinnee/core";
+import { should } from "chai";
+import { ReleaseConfiguration } from "../../src/classLibrary/release/configuration";
+import { CommitConventionDocumentParser } from "../../src/classLibrary/release/documentParser";
+import { ConventionsChecker } from "../../src/classLibrary/release/conventions-checker";
+import { BasicWriter } from "../../src/classLibrary/engine/writer";
+import { VarResolver } from "../../src/classLibrary/engine/resolver";
+import { MarkdownTable } from "../../src/markdown-table";
+import mkdirp = require("mkdirp");
+
+should();
+const core = new Kore();
+core.ExtendPrimitives();
+
+const groundDir = "test_ground/conventions_check";
+const configName = "atomi_release.yaml";
+
+const configuration: ReleaseConfiguration = {
+  gitlint: ".gitlint",
+  committer: {
+    model: "gpt-4o-mini",
+    provider: "openai",
+    variations: 3,
+    maxDiff: 1000,
+  },
+  conventionMarkdown: {
+    // Deliberately nested and containing a space: the real repository config
+    // uses "docs/developer/03-Commit Conventions.md".
+    path: "docs/developer/03-Commit Conventions.md",
+    template: `---
+id: commit-conventions
+title: Commit Conventions
+---
+
+var___convention_docs___
+`,
+  },
+  keywords: ["BREAKING"],
+  branches: ["main"],
+  specialScopes: {
+    "no-release": {
+      desc: "Prevent release from happening",
+      release: false,
+    },
+  },
+  types: [
+    {
+      type: "feat",
+      desc: "A new feature",
+      scopes: {
+        default: { desc: "any part of the project", release: "minor" },
+        core: { desc: "the core library", release: "minor" },
+      },
+      vae: {
+        verb: "add",
+        application: "<title> to <scope>",
+        example: "feat(core): add a brand new thing",
+      },
+    },
+    {
+      type: "fix",
+      desc: "A bug fix",
+      scopes: {
+        default: { desc: "any part of the project", release: "patch" },
+      },
+    },
+  ],
+};
+
+const docPath = path.join(groundDir, configuration.conventionMarkdown.path);
+
+function checker(): ConventionsChecker {
+  const docParser = new CommitConventionDocumentParser(
+    new VarResolver(core),
+    new MarkdownTable(core),
+    core,
+  );
+  return new ConventionsChecker(
+    docParser,
+    new BasicWriter(core, groundDir),
+    groundDir,
+    configName,
+  );
+}
+
+describe("ConventionsChecker", function () {
+  const subject = checker();
+
+  beforeEach(function () {
+    rimraf.sync(groundDir);
+    mkdirp.sync(groundDir);
+  });
+
+  after(function () {
+    rimraf.sync(groundDir);
+  });
+
+  describe("Write", function () {
+    it("should write the generated document to conventionMarkdown.path", async function () {
+      fs.existsSync(docPath).should.equal(false);
+
+      const r = await subject.Write(configuration).promise;
+      r.isOk().should.equal(true);
+      r.unwrap().should.contain("docs/developer/03-Commit Conventions.md");
+
+      fs.existsSync(docPath).should.equal(true);
+      const written = fs.readFileSync(docPath).toString("utf8");
+      written.should.equal(subject.Generate(configuration));
+    });
+
+    it("should write exactly the bytes the document parser generates", async function () {
+      await subject.Write(configuration).promise;
+      const onDisk = fs.readFileSync(docPath);
+      const generated = Buffer.from(subject.Generate(configuration), "utf8");
+      onDisk.equals(generated).should.equal(true);
+    });
+  });
+
+  describe("Check", function () {
+    it("should fail when the document does not exist at all", async function () {
+      fs.existsSync(docPath).should.equal(false);
+
+      const r = await subject.Check(configuration).promise;
+      r.isOk().should.equal(false);
+      r.unwrapErr().should.contain("cannot read");
+      r.unwrapErr().should.contain("sg conventions");
+    });
+
+    it("should pass against a freshly generated document", async function () {
+      await subject.Write(configuration).promise;
+
+      const r = await subject.Check(configuration).promise;
+      r.isOk().should.equal(true);
+      r.unwrap().should.contain("is up to date");
+    });
+
+    it("should fail with a diff when the document is hand-edited, and pass again once regenerated", async function () {
+      await subject.Write(configuration).promise;
+
+      // --- arrange the hand-edit, and prove the hand-edit actually happened ---
+      const needle = "A new feature";
+      const replacement = "A new feature, but hand-edited";
+
+      const pristine = fs.readFileSync(docPath);
+      const pristineText = pristine.toString("utf8");
+      // If the needle were absent the "edit" would silently no-op and the
+      // check would go green for the wrong reason. Assert the precondition.
+      pristineText.should.contain(needle);
+
+      const editedText = pristineText.replace(needle, replacement);
+      editedText.should.not.equal(pristineText);
+      fs.writeFileSync(docPath, Buffer.from(editedText, "utf8"));
+
+      // Assert the MUTATION, not just the verdict: the bytes on disk changed.
+      const edited = fs.readFileSync(docPath);
+      edited.equals(pristine).should.equal(false);
+
+      // --- the check must go red, and say why ---
+      const red = await subject.Check(configuration).promise;
+      red.isOk().should.equal(false);
+      const err = red.unwrapErr();
+      err.should.contain("does not match");
+      err.should.contain("regenerate-only");
+      err.should.contain("sg conventions");
+      err.should.contain("@@");
+      // both sides of the edit are visible in the diff
+      err.should.contain(needle);
+      err.should.contain(replacement);
+
+      // --- Check must not repair the file: it is read-only ---
+      fs.readFileSync(docPath).equals(edited).should.equal(true);
+
+      // --- regenerating must restore the exact bytes and go green ---
+      const rewrite = await subject.Write(configuration).promise;
+      rewrite.isOk().should.equal(true);
+      fs.readFileSync(docPath).equals(pristine).should.equal(true);
+
+      const green = await subject.Check(configuration).promise;
+      green.isOk().should.equal(true);
+    });
+
+    it("should fail on a whitespace-only hand-edit, because the comparison is byte-exact", async function () {
+      await subject.Write(configuration).promise;
+
+      const pristine = fs.readFileSync(docPath);
+      const edited = Buffer.concat([pristine, Buffer.from("\n", "utf8")]);
+      fs.writeFileSync(docPath, edited);
+
+      // Assert the mutation: exactly one byte longer.
+      const onDisk = fs.readFileSync(docPath);
+      onDisk.length.should.equal(pristine.length + 1);
+      onDisk.equals(pristine).should.equal(false);
+
+      const r = await subject.Check(configuration).promise;
+      r.isOk().should.equal(false);
+      r.unwrapErr().should.contain("does not match");
+    });
+
+    it("should fail when the document is truncated to nothing", async function () {
+      await subject.Write(configuration).promise;
+
+      const pristine = fs.readFileSync(docPath);
+      pristine.length.should.be.above(0);
+      fs.writeFileSync(docPath, Buffer.from("", "utf8"));
+      fs.readFileSync(docPath).length.should.equal(0);
+
+      const r = await subject.Check(configuration).promise;
+      r.isOk().should.equal(false);
+      r.unwrapErr().should.contain("does not match");
+    });
+
+    it("should fail when the config changes but the document is left stale", async function () {
+      await subject.Write(configuration).promise;
+      const stale = fs.readFileSync(docPath);
+
+      const changed: ReleaseConfiguration = {
+        ...configuration,
+        types: [
+          ...configuration.types,
+          {
+            type: "chore",
+            desc: "Housekeeping",
+            scopes: { default: { desc: "anything", release: false } },
+          },
+        ],
+      };
+
+      // Assert the mutation is on the CONFIG side: the generated document
+      // genuinely differs now, while the file on disk is untouched.
+      subject
+        .Generate(changed)
+        .should.not.equal(subject.Generate(configuration));
+      fs.readFileSync(docPath).equals(stale).should.equal(true);
+
+      const r = await subject.Check(changed).promise;
+      r.isOk().should.equal(false);
+      r.unwrapErr().should.contain("chore");
+    });
+  });
+});


### PR DESCRIPTION
Adds `sg conventions` and `sg conventions --check`.

**Base is `local-install`, not `master`.** `master` is a one-commit skeleton at version `0.0.1`;
`local-install` is the live line at `0.11.0` matching the published npm `latest`.

This PR carries **two adjacent but different halves**. They are stated separately on purpose, they
enforce different rules, and each has its own arms.

---

## Half 1 — `--check` enforces **D9** (generated docs are regenerate-only)

D9 makes releaser-generated documents regenerate-only: hand-edits are violations. Nothing enforced
it, so drift was invisible.

`sg conventions --check` regenerates the commit convention document in memory from the release
config, compares it **byte-for-byte** against the file on disk, and exits non-zero with a readable
unified diff when they differ. It **never writes**, so it is safe in CI and on a read-only checkout.

Plain `sg conventions` writes the document, so the remedy for a failing check is a **runnable
command** rather than an instruction to hand-edit the file — which is the thing D9 forbids.

The generator is **reused, not reimplemented**: `ConventionsChecker` calls the same
`CommitConventionDocumentParser.GenerateDocument` that `ReleaseExecutor.Release` writes, so the
check and the release cannot drift apart.

### This repo was already in violation

`sg conventions --check` run against the committed bytes of `origin/local-install` **exits 1**.
`a076d18 "feat: pin dependencies"` (2024-06-05) changed two scope descriptions in
`atomi_release.yaml` from `nix` to `old-nix` and never regenerated
`docs/developer/03-Commit Conventions.md`. The document has said `nix` ever since. Nothing caught
it because nothing checked. A dated instance, not a principle.

`9c70337` is the D9 remedy applied as D9 prescribes — the output of `sg conventions`, not a
hand-edit. The rest of the 5.6 KB document reproduces byte-for-byte, so the diff is only the six
drifted lines. **That commit is deliberately separate and droppable**: take the check without the
content change if you prefer. If the *config* wording is what is actually wrong, drop `9c70337`,
fix `atomi_release.yaml`, and run `sg conventions` — either route goes green, and only one of them
is a hand-edit.

---

## Half 2 — `-c/--config` unblocks the **D6 / WF3** config rename

`sg conventions -c <path>` reads a config under any name, so a repo that has renamed
`atomi_release.yaml` to `release.yaml` is not stranded.

No second config name is hardcoded anywhere. `config-reader.ts` now exports
`DefaultReleaseConfigPath`, which is the **only** place the default name is spelled — help text and
messages read it from there — so WF3's rename is a one-line change.

**On the report that "`conventions` has no `-c` and hardcodes `atomi_release.yaml`":** on this repo
at this base there is **no `conventions` subcommand at all**. Base `e34031a`'s own `--help` lists
exactly `release`, `gitlint`, `committer`, `help`. There was no pre-existing command to add a flag
to; the flag is on it from birth.

---

## Acceptance evidence

`sabotage/conventions-check.sh` materialises the **committed bytes of HEAD** into throwaway
sandboxes, drives them with a `dist/` **rebuilt from that same source**, and runs 4 preflight
controls plus 13 arms. Full transcript committed at `sabotage/conventions-check.out`.

**50 assertions executed, 50 passed, 0 failed.** Population is every assertion the harness emits;
nothing is sampled and nothing is skipped.

Every arm **asserts the sabotage itself landed** — sha256, byte length or existence moved in the
intended direction — *before* it reads any verdict. A setup step that silently no-ops produces a
false green, and an exit code alone cannot tell the two apart.

### Graded claims

- **`--check` refuses a hand-edited document.** Shown able to go red on four distinct sabotages:
  edited body (A2), one appended whitespace byte (A3), missing file (A4), config-side drift (A5).
  — **STRONG.**
- **`--check` is content-based, not write-based.** A byte-identical rewrite of the same file stays
  green (A6), so the red arms above carry information rather than reacting to any write at all.
  — **STRONG.**
- **`--check` never modifies the file it judges.** sha256 unchanged across a failing run (A7), so
  CI cannot silently self-heal and hide the violation. — **STRONG.**
- **`--check` does not pass when it cannot read its config.** Exits non-zero on an absent config
  (A8) rather than reporting "safe" for the wrong reason. — **STRONG.**
- **`sg conventions` is a real remedy.** Restores the exact committed bytes and turns the check
  green (A9). — **STRONG.**
- **`-c` is read on the write path.** With **both** config names present and a unique marker in
  only the named one, the marker reaches the generated document (B3). This is what separates "read
  my config" from "ignored my flag and found `atomi_release.yaml` anyway"; B1's exit 0 alone cannot.
  — **STRONG.**
- **`-c` is read on the check path.** Same both-configs sandbox: `--check -c release.yaml` goes
  **red** citing the marker, while the identical document checked against the unmarked config goes
  **green** (B4). — **STRONG.**
- **`--check` and `--config` are registered on the subcommand's own parser.** Verified against
  commander's own `conventions --help` output (P4), not against intent — a flag swallowed by an
  outer parser exits 0 and checks nothing. — **STRONG.**
- **The feature is actually in the build.** `tsc` does not bundle, so P3 asserts the three emitted
  modules exist as files under `dist/` rather than grepping the small entry shim, which would pass
  unconditionally. — **STRONG.**
- **What the original reporter measured.** I could not reproduce a pre-existing `conventions`
  command, and their positive control (exit 0 **and writes**) is impossible against a command that
  does not exist — so they were driving an artifact I cannot name. — **UNCONTROLLED.** I have not
  seen their shell.

### Unit tests

`pnpm test`: **81 passing, 3 failing** (22 new tests). The 3 failures are **pre-existing and not
from this PR** — `tests/release/configuration.spec.ts` asserts ANSI colour escapes and chalk emits
none off-TTY. Base `origin/local-install` is **59 passing / 3 failing** with the *same three* tests
failing for the same reason; confirmed on the base commit before anything here changed.

---

## Out of scope, stated plainly

**CI on this repo is pre-existing dead and this PR does not fix it.** `.github/workflows/ci.yaml`
targets the retired `ubuntu-20.04` runner and installs from `./ci-env.old-nix`, a file absent from
the entire tree. Both jobs fail at *Install Environment* on the base commit too. Do not read a red
CI check here as a signal about this change.

---

## Independently mergeable

Nothing here depends on WF1, WF3 or any other branch, and the commits are ordered so the owner can
merge out of order. It pairs with WF1 on the workspace side — where `docs/developer/CommitConventions.md`
becomes single-source-generated and carries a generated-file header, and this check is what makes
that header enforceable — but no file in the workspace repo is touched here and WF1 does not need
to land first.
